### PR TITLE
Perform fairly big reorganization of code, add in SHA1

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,16 @@ julia> sha256("test")
 "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
 ```
 
-Each exported function (at the time of this writing, only SHA-2 224, 256, 384 and 512 functions are implemented) takes in either an `Array{Uint8}`, a `ByteString` or an `IO` object.  This makes it trivial to checksum a file:
+Each exported function (at the time of this writing, only SHA-1, SHA-2 224, 256, 384 and 512 functions are implemented) takes in either an `Array{Uint8}`, a `ByteString` or an `IO` object.  This makes it trivial to checksum a file:
 
 ```
 shell> cat /tmp/test.txt
 test
 julia> using SHA
 
-julia> sha256(open("/tmp/test.txt"))
+julia> open("/tmp/test.txt") do f
+           sha256(f)
+       end
 "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
 ```
 

--- a/src/SHA.jl
+++ b/src/SHA.jl
@@ -14,16 +14,19 @@ include("common.jl")
 
 # Create data types and convenience functions for each hash implemented
 for (f, ctx) in [(:sha1, :SHA1_CTX),
-				 (:sha224, :SHA224_CTX),
+                 (:sha224, :SHA224_CTX),
                  (:sha256, :SHA256_CTX),
                  (:sha384, :SHA384_CTX),
                  (:sha512, :SHA512_CTX)]
     @eval begin
-    	# Allows e.g. sha256(open("test.txt"))
+        # Allows things like:
+        # open("test.txt") do f
+        #     sha256(f)
+        # done
         function $f(io::IO)
-        	ctx = $ctx()
-        	update!(ctx, readbytes(io));
-			return bytes2hex(digest!(ctx))
+            ctx = $ctx()
+            update!(ctx, readbytes(io));
+            return bytes2hex(digest!(ctx))
         end
 
         # Allows the same as above, but on ByteStrings and Arrays

--- a/src/SHA.jl
+++ b/src/SHA.jl
@@ -2,25 +2,34 @@ module SHA
 
 using Compat
 
-export sha224, sha256, sha384, sha512
+export sha1, sha224, sha256, sha384, sha512
 
 include("constants.jl")
-include("base_functions.jl")
 include("types.jl")
+include("base_functions.jl")
+include("sha1.jl")
 include("sha2.jl")
+include("common.jl")
 
-_shasum(ctx::SHA_CTX, io::IO) =
-    (update!(ctx, readbytes(io)); bytes2hex(digest!(ctx)))
 
-for (f, ctx) in [(:sha224, :SHA224_CTX),
+# Create data types and convenience functions for each hash implemented
+for (f, ctx) in [(:sha1, :SHA1_CTX),
+				 (:sha224, :SHA224_CTX),
                  (:sha256, :SHA256_CTX),
                  (:sha384, :SHA384_CTX),
                  (:sha512, :SHA512_CTX)]
     @eval begin
-        $f(io::IO) = _shasum($ctx(), io)
+    	# Allows e.g. sha256(open("test.txt"))
+        function $f(io::IO)
+        	ctx = $ctx()
+        	update!(ctx, readbytes(io));
+			return bytes2hex(digest!(ctx))
+        end
+
+        # Allows the same as above, but on ByteStrings and Arrays
         $f(str::ByteString) = $f(IOBuffer(str))
         $f(arr::Array{UInt8,1}) = $f(IOBuffer(arr))
     end
 end
 
-end
+end #module SHA

--- a/src/base_functions.jl
+++ b/src/base_functions.jl
@@ -3,20 +3,24 @@
 # Bit shifting and rotation (used by the six SHA-XYZ logical functions:
 #
 #   NOTE:  The naming of R and S appears backwards here (R is a SHIFT and
-#   S is a ROTATION) because the SHA-256/384/512 description document
+#   S is a ROTATION) because the SHA2-256/384/512 description document
 #   (see http://csrc.nist.gov/cryptval/shs/sha256-384-512.pdf) uses this
 #   same "backwards" definition.
 
+# 32-bit Rotate-right (equivalent to S32 in SHA-256) and rotate-left
+rrot(b,x,width) = ((x >> b) | (x << (width - b)))
+lrot(b,x,width) = ((x << b) | (x >> (width - b)))
+
 # Shift-right (used in SHA-256, SHA-384, and SHA-512):
-R(b,x)     = ((x) >> (b))
+R(b,x)          = (x >> b)
 # 32-bit Rotate-right (used in SHA-256):
-S32(b,x)   = (((x) >> (b)) | ((x) << (32 - (b))))
+S32(b,x)        = rrot(b,x,32)
 # 64-bit Rotate-right (used in SHA-384 and SHA-512):
-S64(b,x)   = (((x) >> (b)) | ((x) << (64 - (b))))
+S64(b,x)        = rrot(b,x,64)
 
 # Two of six logical functions used in SHA-256, SHA-384, and SHA-512:
-Ch(x,y,z)  = (((x) & (y)) $ ((~(x)) & (z)))
-Maj(x,y,z) = (((x) & (y)) $ ((x) & (z)) $ ((y) & (z)))
+Ch(x,y,z)  = ((x & y) $ (~x & z))
+Maj(x,y,z) = ((x & y) $ (x & z) $ (y & z))
 
 # Four of six logical functions used in SHA-256:
 Sigma0_256(x) =   (S32(2,  @compat(UInt32(x))) $ S32(13, @compat(UInt32(x))) $ S32(22, @compat(UInt32(x))))
@@ -34,3 +38,6 @@ sigma1_512(x) =   (S64(19, @compat(UInt64(x))) $ S64(61, @compat(UInt64(x))) $ R
 bswap!(x::Vector{UInt32})  = map!(bswap, x)
 bswap!(x::Vector{UInt64})  = map!(bswap, x)
 bswap!(x::Vector{UInt128}) = map!(bswap, x)
+
+# A mod function which maps [0..N-1] to [1..N]
+mod1(i, N) = mod(i-1, N) + 1

--- a/src/base_functions.jl
+++ b/src/base_functions.jl
@@ -38,6 +38,3 @@ sigma1_512(x) =   (S64(19, @compat(UInt64(x))) $ S64(61, @compat(UInt64(x))) $ R
 bswap!(x::Vector{UInt32})  = map!(bswap, x)
 bswap!(x::Vector{UInt64})  = map!(bswap, x)
 bswap!(x::Vector{UInt128}) = map!(bswap, x)
-
-# A mod function which maps [0..N-1] to [1..N]
-mod1(i, N) = mod(i-1, N) + 1

--- a/src/common.jl
+++ b/src/common.jl
@@ -1,0 +1,100 @@
+# Common update and digest functions which work across SHA1 and SHA2
+
+# update! takes in variable-length data, buffering it into blocklen()-sized pieces,
+# calling transform!() when necessary to update the internal hash state.
+function update!{T<:SHA_CTX}(context::T, data::Array{UInt8,1})
+    if length(data) == 0
+        return
+    end
+
+    data_idx = 0
+    len = convert(typeof(context.bytecount), length(data))
+    usedspace = context.bytecount % blocklen(T)
+    if usedspace > 0
+        # Calculate how much free space is available in the buffer
+        freespace = blocklen(T) - usedspace
+
+        if len >= freespace
+            # Fill the buffer completely and process it
+            context.buffer[blocklen(T)-usedspace:blocklen(T)] = data[data_idx:data_idx+freespace]
+
+            # Round bytecount up to the nearest blocklen
+            context.bytecount += freespace
+            data_idx += freespace
+            len -= freespace
+            transform!(context)
+        else
+            # The buffer is not yet full
+            for i = 1:len
+                context.buffer[usedspace + i] = data[data_idx + i]
+            end
+            context.bytecount += len
+            return
+        end
+    end
+
+
+    # Process as many complete blocks as possible, now that the buffer is full
+    data_idx = one(len)
+    while len - (data_idx - 1) >= blocklen(T)
+        context.buffer[1:end] = data[data_idx:data_idx+blocklen(T)-1]
+        transform!(context)
+        data_idx += blocklen(T)
+    end
+    context.bytecount += (data_idx - 1)
+
+    # If there are leftovers, save them in buffer until next update!() or digest!()
+    if data_idx < len
+        # There's left-overs, so save 'em
+        for i = 1:(len - data_idx + 1)
+            context.buffer[i] = data[data_idx + i - 1]
+        end
+        context.bytecount += (len - data_idx + 1)
+    end
+end
+
+
+# Clear out any saved data in the buffer, append total bitlength, and return our precious hash!
+function digest!{T<:SHA_CTX}(context::T)
+    usedspace = context.bytecount % blocklen(T)
+
+    # If we have anything in the buffer still, pad and transform that data
+    if usedspace > 0
+        # Begin padding with a 1 bit:
+        context.buffer[usedspace+1] = 0x80
+        usedspace += 1
+
+        # If we have room for the bitcount, then pad up to the short blocklen
+        if usedspace <= short_blocklen(T)
+            for i = 1:(short_blocklen(T) - usedspace)
+                context.buffer[usedspace + i] = 0x0
+            end
+        else
+            # Otherwise, pad out this entire block, transform it, then pad up to short blocklen
+            for i = 1:(blocklen(T) - usedspace)
+                context.buffer[usedspace + i] = 0x0
+            end
+            transform!(context)
+            for i = 1:short_blocklen(T)
+                context.buffer[i] = 0x0
+            end
+        end
+    else
+        # If we don't have anything in the buffer, pad an entire shortbuffer
+        context.buffer[1] = 0x80
+        for i = 2:short_blocklen(T)
+            context.buffer[i] = 0x0
+        end
+    end
+
+    # Store the length of the input data (in bits)
+    bitcount_buffer = reinterpret(typeof(context.bytecount), context.buffer)
+    bitcount_idx = div(short_blocklen(T), sizeof(context.bytecount))+1
+    bitcount_buffer[bitcount_idx] = bswap(context.bytecount*8)
+
+    # Final transform:
+    transform!(context)
+
+    # Return the digest
+    return reinterpret(UInt8, bswap!(context.state))[1:digestlen(T)]
+end

--- a/src/constants.jl
+++ b/src/constants.jl
@@ -1,4 +1,17 @@
-# SHA-XYZ INITIAL HASH VALUES AND CONSTANTS
+# SHA initial hash values and constants
+
+# Hash constant words K for SHA1
+const K1 = Uint32[
+    0x5a827999, 0x6ed9eba1, 0x8f1bbcdc, 0xca62c1d6
+]
+
+# Initial hash value H for SHA1
+const SHA1_initial_hash_value = Uint32[
+    0x67452301, 0xefcdab89, 0x98badcfe, 0x10325476, 0xc3d2e1f0
+]
+
+
+
 # Hash constant words K for SHA-256:
 const K256 = UInt32[
     0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5,
@@ -20,27 +33,15 @@ const K256 = UInt32[
 ]
 
 # Initial hash value H for SHA-224:
-const sha224_initial_hash_value = UInt32[
-    0xc1059ed8,
-    0x367cd507,
-    0x3070dd17,
-    0xf70e5939,
-    0xffc00b31,
-    0x68581511,
-    0x64f98fa7,
-    0xbefa4fa4
+const SHA224_initial_hash_value = UInt32[
+    0xc1059ed8, 0x367cd507, 0x3070dd17, 0xf70e5939,
+    0xffc00b31, 0x68581511, 0x64f98fa7, 0xbefa4fa4
 ]
 
 
-const sha256_initial_hash_value = UInt32[
-    0x6a09e667,
-    0xbb67ae85,
-    0x3c6ef372,
-    0xa54ff53a,
-    0x510e527f,
-    0x9b05688c,
-    0x1f83d9ab,
-    0x5be0cd19
+const SHA256_initial_hash_value = UInt32[
+    0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a,
+    0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19
 ]
 
 # Hash constant words K for SHA-384 and SHA-512:
@@ -88,25 +89,17 @@ const K512 = UInt64[
 ]
 
 # Initial hash value H for SHA-384
-const sha384_initial_hash_value = UInt64[
-    0xcbbb9d5dc1059ed8,
-    0x629a292a367cd507,
-    0x9159015a3070dd17,
-    0x152fecd8f70e5939,
-    0x67332667ffc00b31,
-    0x8eb44a8768581511,
-    0xdb0c2e0d64f98fa7,
-    0x47b5481dbefa4fa4
+const SHA384_initial_hash_value = UInt64[
+    0xcbbb9d5dc1059ed8, 0x629a292a367cd507,
+    0x9159015a3070dd17, 0x152fecd8f70e5939,
+    0x67332667ffc00b31, 0x8eb44a8768581511,
+    0xdb0c2e0d64f98fa7, 0x47b5481dbefa4fa4
 ]
 
 # Initial hash value H for SHA-512
-const sha512_initial_hash_value = UInt64[
-    0x6a09e667f3bcc908,
-    0xbb67ae8584caa73b,
-    0x3c6ef372fe94f82b,
-    0xa54ff53a5f1d36f1,
-    0x510e527fade682d1,
-    0x9b05688c2b3e6c1f,
-    0x1f83d9abfb41bd6b,
-    0x5be0cd19137e2179
+const SHA512_initial_hash_value = UInt64[
+    0x6a09e667f3bcc908, 0xbb67ae8584caa73b,
+    0x3c6ef372fe94f82b, 0xa54ff53a5f1d36f1,
+    0x510e527fade682d1, 0x9b05688c2b3e6c1f,
+    0x1f83d9abfb41bd6b, 0x5be0cd19137e2179
 ]

--- a/src/sha1.jl
+++ b/src/sha1.jl
@@ -1,0 +1,93 @@
+# Nonlinear functions, in order to encourage inlining, these sadly are not an array of lambdas
+function Round0(b,c,d)
+	return @compat(UInt32((b & c) | (~b & d)))
+end
+
+function Round1And3(b,c,d)
+	return @compat(UInt32(b $ c $ d))
+end
+
+function Round2(b,c,d)
+	return @compat(UInt32((b & c) | (b & d) | (c & d)))
+end
+
+function transform!(context::SHA1_CTX)
+	# Buffer is 16 elements long, we expand to 80
+	buffer = reinterpret(eltype(context.state), context.buffer)
+	for i in 1:16
+		context.W[i] = bswap(buffer[i])
+	end
+
+	# First round of expansions
+	for i in 17:32
+		@inbounds begin
+			context.W[i] = lrot(1, context.W[i-3] $ context.W[i-8] $ context.W[i-14] $ context.W[i-16], 32)
+		end
+	end
+
+	# Second round of expansions (possibly 4-way SIMD-able)
+	for i in 33:80
+		@inbounds begin
+			context.W[i] = lrot(2, context.W[i-6] $ context.W[i-16] $ context.W[i-28] $ context.W[i-32], 32)
+		end
+	end
+
+	# Initialize registers with the previous intermediate values (our state)
+	a = context.state[1]
+	b = context.state[2]
+	c = context.state[3]
+	d = context.state[4]
+	e = context.state[5]
+
+	# Run our rounds, manually separated into the four rounds, unfortunately using an array of lambdas
+	# really kills performance and causes a huge number of allocations, so we make it easy on the compiler
+	for i = 1:20
+		@inbounds begin
+			temp = @compat(UInt32(lrot(5, a, 32) + Round0(b,c,d) + e + context.W[i] + K1[1]))
+	        e = d
+	        d = c
+	        c = lrot(30, b, 32)
+	        b = a
+	        a = temp
+		end
+	end
+
+	for i = 21:40
+		@inbounds begin
+			temp = @compat(UInt32(lrot(5, a, 32) + Round1And3(b,c,d) + e + context.W[i] + K1[2]))
+	        e = d
+	        d = c
+	        c = lrot(30, b, 32)
+	        b = a
+	        a = temp
+		end
+	end
+
+	for i = 41:60
+		@inbounds begin
+			temp = @compat(UInt32(lrot(5, a, 32) + Round2(b,c,d) + e + context.W[i] + K1[3]))
+	        e = d
+	        d = c
+	        c = lrot(30, b, 32)
+	        b = a
+	        a = temp
+		end
+	end
+
+	for i = 61:80
+		@inbounds begin
+			temp = @compat(UInt32(lrot(5, a, 32) + Round1And3(b,c,d) + e + context.W[i] + K1[4]))
+	        e = d
+	        d = c
+	        c = lrot(30, b, 32)
+	        b = a
+	        a = temp
+		end
+	end
+
+	context.state[1] += a
+	context.state[2] += b
+	context.state[3] += c
+	context.state[4] += d
+	context.state[5] += e
+end

--- a/src/sha1.jl
+++ b/src/sha1.jl
@@ -1,93 +1,93 @@
 # Nonlinear functions, in order to encourage inlining, these sadly are not an array of lambdas
 function Round0(b,c,d)
-	return @compat(UInt32((b & c) | (~b & d)))
+    return @compat(UInt32((b & c) | (~b & d)))
 end
 
 function Round1And3(b,c,d)
-	return @compat(UInt32(b $ c $ d))
+    return @compat(UInt32(b $ c $ d))
 end
 
 function Round2(b,c,d)
-	return @compat(UInt32((b & c) | (b & d) | (c & d)))
+    return @compat(UInt32((b & c) | (b & d) | (c & d)))
 end
 
 function transform!(context::SHA1_CTX)
-	# Buffer is 16 elements long, we expand to 80
-	buffer = reinterpret(eltype(context.state), context.buffer)
-	for i in 1:16
-		context.W[i] = bswap(buffer[i])
-	end
+    # Buffer is 16 elements long, we expand to 80
+    buffer = reinterpret(eltype(context.state), context.buffer)
+    for i in 1:16
+        context.W[i] = bswap(buffer[i])
+    end
 
-	# First round of expansions
-	for i in 17:32
-		@inbounds begin
-			context.W[i] = lrot(1, context.W[i-3] $ context.W[i-8] $ context.W[i-14] $ context.W[i-16], 32)
-		end
-	end
+    # First round of expansions
+    for i in 17:32
+        @inbounds begin
+            context.W[i] = lrot(1, context.W[i-3] $ context.W[i-8] $ context.W[i-14] $ context.W[i-16], 32)
+        end
+    end
 
-	# Second round of expansions (possibly 4-way SIMD-able)
-	for i in 33:80
-		@inbounds begin
-			context.W[i] = lrot(2, context.W[i-6] $ context.W[i-16] $ context.W[i-28] $ context.W[i-32], 32)
-		end
-	end
+    # Second round of expansions (possibly 4-way SIMD-able)
+    for i in 33:80
+        @inbounds begin
+            context.W[i] = lrot(2, context.W[i-6] $ context.W[i-16] $ context.W[i-28] $ context.W[i-32], 32)
+        end
+    end
 
-	# Initialize registers with the previous intermediate values (our state)
-	a = context.state[1]
-	b = context.state[2]
-	c = context.state[3]
-	d = context.state[4]
-	e = context.state[5]
+    # Initialize registers with the previous intermediate values (our state)
+    a = context.state[1]
+    b = context.state[2]
+    c = context.state[3]
+    d = context.state[4]
+    e = context.state[5]
 
-	# Run our rounds, manually separated into the four rounds, unfortunately using an array of lambdas
-	# really kills performance and causes a huge number of allocations, so we make it easy on the compiler
-	for i = 1:20
-		@inbounds begin
-			temp = @compat(UInt32(lrot(5, a, 32) + Round0(b,c,d) + e + context.W[i] + K1[1]))
-	        e = d
-	        d = c
-	        c = lrot(30, b, 32)
-	        b = a
-	        a = temp
-		end
-	end
+    # Run our rounds, manually separated into the four rounds, unfortunately using an array of lambdas
+    # really kills performance and causes a huge number of allocations, so we make it easy on the compiler
+    for i = 1:20
+        @inbounds begin
+            temp = @compat(UInt32(lrot(5, a, 32) + Round0(b,c,d) + e + context.W[i] + K1[1]))
+            e = d
+            d = c
+            c = lrot(30, b, 32)
+            b = a
+            a = temp
+        end
+    end
 
-	for i = 21:40
-		@inbounds begin
-			temp = @compat(UInt32(lrot(5, a, 32) + Round1And3(b,c,d) + e + context.W[i] + K1[2]))
-	        e = d
-	        d = c
-	        c = lrot(30, b, 32)
-	        b = a
-	        a = temp
-		end
-	end
+    for i = 21:40
+        @inbounds begin
+            temp = @compat(UInt32(lrot(5, a, 32) + Round1And3(b,c,d) + e + context.W[i] + K1[2]))
+            e = d
+            d = c
+            c = lrot(30, b, 32)
+            b = a
+            a = temp
+        end
+    end
 
-	for i = 41:60
-		@inbounds begin
-			temp = @compat(UInt32(lrot(5, a, 32) + Round2(b,c,d) + e + context.W[i] + K1[3]))
-	        e = d
-	        d = c
-	        c = lrot(30, b, 32)
-	        b = a
-	        a = temp
-		end
-	end
+    for i = 41:60
+        @inbounds begin
+            temp = @compat(UInt32(lrot(5, a, 32) + Round2(b,c,d) + e + context.W[i] + K1[3]))
+            e = d
+            d = c
+            c = lrot(30, b, 32)
+            b = a
+            a = temp
+        end
+    end
 
-	for i = 61:80
-		@inbounds begin
-			temp = @compat(UInt32(lrot(5, a, 32) + Round1And3(b,c,d) + e + context.W[i] + K1[4]))
-	        e = d
-	        d = c
-	        c = lrot(30, b, 32)
-	        b = a
-	        a = temp
-		end
-	end
+    for i = 61:80
+        @inbounds begin
+            temp = @compat(UInt32(lrot(5, a, 32) + Round1And3(b,c,d) + e + context.W[i] + K1[4]))
+            e = d
+            d = c
+            c = lrot(30, b, 32)
+            b = a
+            a = temp
+        end
+    end
 
-	context.state[1] += a
-	context.state[2] += b
-	context.state[3] += c
-	context.state[4] += d
-	context.state[5] += e
+    context.state[1] += a
+    context.state[2] += b
+    context.state[3] += c
+    context.state[4] += d
+    context.state[5] += e
 end

--- a/src/sha2.jl
+++ b/src/sha2.jl
@@ -1,10 +1,6 @@
-# A mod function which maps [0..N-1] to [1..N]
-mod1(i, N) = mod(i-1, N) + 1
-
-function transform!{T<:SHA_CTX_SMALL}(context::T, data::Array{UInt32,1}, startidx = 0)
-    W256 = context.buffer
-
-    # Initialize registers with the prev. intermediate value
+function transform!{T<:SHA2_CTX_SMALL}(context::T)
+    buffer = reinterpret(eltype(context.state), context.buffer)
+    # Initialize registers with the previous intermediate values (our state)
     a = context.state[1]
     b = context.state[2]
     c = context.state[3]
@@ -14,43 +10,46 @@ function transform!{T<:SHA_CTX_SMALL}(context::T, data::Array{UInt32,1}, startid
     g = context.state[7]
     h = context.state[8]
 
+    # Run initial rounds
     for j = 1:16
         @inbounds begin
-            W256[j] = bswap(data[startidx + j])
+            # We bitswap every input byte
+            buffer[j] = bswap(buffer[j])
 
             # Apply the SHA-256 compression function to update a..h
-            T1 = h + Sigma1_256(e) + Ch(e, f, g) + K256[j] + W256[j];
-            T2 = Sigma0_256(a) + Maj(a, b, c);
-            h = g;
-            g = f;
-            f = e;
-            e = @compat UInt32(d + T1);
-            d = c;
-            c = b;
-            b = a;
-            a = @compat UInt32(T1 + T2);
+            T1 = h + Sigma1_256(e) + Ch(e, f, g) + K256[j] + buffer[j]
+            T2 = Sigma0_256(a) + Maj(a, b, c)
+            h = g
+            g = f
+            f = e
+            e = @compat UInt32(d + T1)
+            d = c
+            c = b
+            b = a
+            a = @compat UInt32(T1 + T2)
         end
     end
 
     for j = 17:64
         @inbounds begin
-            # Part of the message block expansion:
-            s0 = W256[mod1(j + 1, 16)];
-            s0 = sigma0_256(s0);
-            s1 = W256[mod1(j + 14, 16)];
-            s1 = sigma1_256(s1);
+            # Implicit message block expansion:
+            s0 = buffer[mod1(j + 1, 16)]
+            s0 = sigma0_256(s0)
+            s1 = buffer[mod1(j + 14, 16)]
+            s1 = sigma1_256(s1)
 
             # Apply the SHA-256 compression function to update a..h
-            T1 = h + Sigma1_256(e) + Ch(e, f, g) + K256[j] + (W256[mod1(j, 16)] += s1 + W256[mod1(j + 9,16)] + s0);
-            T2 = Sigma0_256(a) + Maj(a, b, c);
-            h = g;
-            g = f;
-            f = e;
-            e = @compat UInt32(d + T1);
-            d = c;
-            c = b;
-            b = a;
-            a = @compat UInt32(T1 + T2);
+            buffer[mod1(j, 16)] += s1 + buffer[mod1(j + 9,16)] + s0
+            T1 = h + Sigma1_256(e) + Ch(e, f, g) + K256[j] + buffer[mod1(j, 16)]
+            T2 = Sigma0_256(a) + Maj(a, b, c)
+            h = g
+            g = f
+            f = e
+            e = @compat UInt32(d + T1)
+            d = c
+            c = b
+            b = a
+            a = @compat UInt32(T1 + T2)
         end
     end
 
@@ -66,9 +65,8 @@ function transform!{T<:SHA_CTX_SMALL}(context::T, data::Array{UInt32,1}, startid
 end
 
 
-function transform!(context::SHA_CTX_BIG, data::Array{UInt64,1}, startidx = 0)
-    W512 = context.buffer # reinterpret( UInt64, context.buffer )
-
+function transform!(context::SHA2_CTX_BIG)
+    buffer = reinterpret(eltype(context.state), context.buffer)
     # Initialize registers with the prev. intermediate value
     a = context.state[1]
     b = context.state[2]
@@ -81,41 +79,42 @@ function transform!(context::SHA_CTX_BIG, data::Array{UInt64,1}, startidx = 0)
 
     for j = 1:16
         @inbounds begin
-            W512[j] = bswap(data[startidx + j])
+            buffer[j] = bswap(buffer[j])
 
             # Apply the SHA-512 compression function to update a..h
-            T1 = h + Sigma1_512(e) + Ch(e, f, g) + K512[j] + W512[j];
-            T2 = Sigma0_512(a) + Maj(a, b, c);
-            h = g;
-            g = f;
-            f = e;
-            e = d + T1;
-            d = c;
-            c = b;
-            b = a;
-            a = T1 + T2;
+            T1 = h + Sigma1_512(e) + Ch(e, f, g) + K512[j] + buffer[j]
+            T2 = Sigma0_512(a) + Maj(a, b, c)
+            h = g
+            g = f
+            f = e
+            e = d + T1
+            d = c
+            c = b
+            b = a
+            a = T1 + T2
         end
     end
 
     for j = 17:80
         @inbounds begin
-            # Part of the message block expansion:
-            s0 = W512[mod1(j + 1, 16)];
-            s0 = sigma0_512(s0);
-            s1 = W512[mod1(j+14, 16)];
-            s1 = sigma1_512(s1);
+            # Implicit message block expansion:
+            s0 = buffer[mod1(j + 1, 16)]
+            s0 = sigma0_512(s0)
+            s1 = buffer[mod1(j+14, 16)]
+            s1 = sigma1_512(s1)
 
             # Apply the SHA-512 compression function to update a..h
-            T1 = h + Sigma1_512(e) + Ch(e, f, g) + K512[j] + (W512[mod1(j, 16)] += s1 + W512[mod1(j+9, 16)] + s0);
-            T2 = Sigma0_512(a) + Maj(a, b, c);
-            h = g;
-            g = f;
-            f = e;
-            e = d + T1;
-            d = c;
-            c = b;
-            b = a;
-            a = T1 + T2;
+            buffer[mod1(j, 16)] += s1 + buffer[mod1(j+9, 16)] + s0
+            T1 = h + Sigma1_512(e) + Ch(e, f, g) + K512[j] + buffer[mod1(j, 16)]
+            T2 = Sigma0_512(a) + Maj(a, b, c)
+            h = g
+            g = f
+            f = e
+            e = d + T1
+            d = c
+            c = b
+            b = a
+            a = T1 + T2
         end
     end
 
@@ -128,109 +127,4 @@ function transform!(context::SHA_CTX_BIG, data::Array{UInt64,1}, startidx = 0)
     context.state[6] += f
     context.state[7] += g
     context.state[8] += h
-end
-
-
-function update!(context::SHA_CTX, data::Array{UInt8,1})
-    if length(data) == 0
-        return
-    end
-
-    data_idx = 0
-    len = convert(typeof(context.bitcount), length(data))
-    usedspace = div(context.bitcount, 8) % context.blocklen
-    freespace = 0
-    if usedspace > 0
-        # Calculate how much free space is available in the buffer
-        freespace = context.blocklen - usedspace
-
-        if len >= freespace
-            # Fill the buffer completely and process it
-            buffer = reinterpret(UInt8, context.buffer)
-            for i = 1:freespace
-                buffer[usedspace + i] = data[data_idx + i]
-            end
-            context.bitcount += freespace * 8
-            len -= freespace
-            data_idx += freespace
-            transform!(context, context.buffer)
-        else
-            # The buffer is not yet full
-            buffer = reinterpret(UInt8, context.buffer)
-            for i = 1:len
-                buffer[usedspace + i] = data[data_idx + i]
-            end
-            context.bitcount += len * 8
-            return
-        end
-    end
-
-
-    # Process as many complete blocks as possible.
-    data_idx = one(len)
-    data_conv = reinterpret(eltype(context.state), data)
-    while len - (data_idx - 1) >= context.blocklen
-        data_idx_conv = div(data_idx,sizeof(eltype(context.state)))
-        transform!(context, data_conv, data_idx_conv)
-        data_idx += context.blocklen
-    end
-    context.bitcount += (data_idx - 1)*8
-
-    if data_idx < len
-        # There's left-overs, so save 'em
-        buffer = reinterpret(UInt8, context.buffer)
-        for i = 1:(len - data_idx + 1)
-            buffer[i] = data[data_idx + i - 1]
-        end
-        context.bitcount += (len - data_idx + 1) * 8
-    end
-end
-
-# add in a convenience method for strings
-update!(context::SHA_CTX, str::ASCIIString) = update!(context, str.data)
-
-function digest!(context::SHA_CTX)
-    usedspace = div(context.bitcount, 8) % context.blocklen;
-    context.bitcount = bswap(context.bitcount)
-    buffer = reinterpret(UInt8, context.buffer)
-
-    if usedspace > 0
-        # Begin padding with a 1 bit:
-        buffer[usedspace+1] = 0x80
-        usedspace += 1
-        if usedspace <= context.short_blocklen
-            # Set-up for the last transform:
-            for i = 1:(context.short_blocklen - usedspace)
-                buffer[usedspace + i] = 0x0
-            end
-        else
-            for i = 1:(context.blocklen - usedspace)
-                buffer[usedspace + i] = 0x0
-            end
-            # Do second-to-last transform:
-            transform!(context, context.buffer)
-            # And set-up for the last transform:
-            for i = 1:context.short_blocklen
-                buffer[i] = 0x0
-            end
-        end
-    else
-        # Set-up for the last transform:
-        for i = 1:context.short_blocklen
-            buffer[i] = 0x0
-        end
-        # Begin padding with a 1 bit:
-        buffer[1] = 0x80
-    end
-
-    # Store the length of the input data (in bits)
-    bitcount_buffer = reinterpret(typeof(context.bitcount), context.buffer)
-    bitcount_idx = div(context.short_blocklen, sizeof(context.bitcount))+1
-    bitcount_buffer[bitcount_idx] = context.bitcount
-
-    # Final transform:
-    transform!(context, context.buffer)
-
-    # Return the digest
-    return reinterpret(UInt8, bswap!(context.state))[1:context.digest_len]
 end

--- a/test/perf.jl
+++ b/test/perf.jl
@@ -8,28 +8,28 @@ end
 
 
 function do_tests(filepath)
-	# test performance
-	print("read:    ")
-	@time begin
-	    const fh = open(filepath, "r")
-	    const bytes = readbytes(fh)
-	end
-	gc()
+    # test performance
+    print("read:    ")
+    @time begin
+        const fh = open(filepath, "r")
+        const bytes = readbytes(fh)
+    end
+    gc()
 
-	print("SHA-1:   ")
-	sha1(bytes)
-	gc()
-	@time sha1(bytes)
+    print("SHA-1:   ")
+    sha1(bytes)
+    gc()
+    @time sha1(bytes)
 
-	print("SHA-256: ")
-	sha256(bytes)
-	gc()
-	@time sha256(bytes)
+    print("SHA-256: ")
+    sha256(bytes)
+    gc()
+    @time sha256(bytes)
 
-	print("SHA-512: ")
-	sha512(bytes)
-	gc()
-	@time sha512(bytes)
+    print("SHA-512: ")
+    sha512(bytes)
+    gc()
+    @time sha512(bytes)
 end
 
 do_tests(ARGS[1])

--- a/test/perf.jl
+++ b/test/perf.jl
@@ -6,17 +6,30 @@ elseif !isfile(ARGS[1])
     error("file $(ARGS[1]) does not exist")
 end
 
-# test performance
-@time begin
-    const fh = open(ARGS[1], "r")
-    const bytes = readbytes(fh)
+
+function do_tests(filepath)
+	# test performance
+	print("read:    ")
+	@time begin
+	    const fh = open(filepath, "r")
+	    const bytes = readbytes(fh)
+	end
+	gc()
+
+	print("SHA-1:   ")
+	sha1(bytes)
+	gc()
+	@time sha1(bytes)
+
+	print("SHA-256: ")
+	sha256(bytes)
+	gc()
+	@time sha256(bytes)
+
+	print("SHA-512: ")
+	sha512(bytes)
+	gc()
+	@time sha512(bytes)
 end
 
-test_perf() = begin
-    ctx = SHA512_CTX()
-    update!(ctx, bytes)
-    hash = bytes2hex(digest!(ctx))
-end
-
-test_perf()
-@time test_perf()
+do_tests(ARGS[1])


### PR DESCRIPTION
@tkelman I was on a train today; which means I had some quality time with my laptop, and some decidedly low-quality internet.  Turns out I could reuse more code than I thought, which was nice!

Performance isn't horrible; try out `julia test/perf.jl <input file>`, but I think I might need to use subarrays in a few places to avoid excessive allocations.  Let me know what you think!  My guess is that [this line](https://github.com/staticfloat/SHA.jl/blob/05ecc992d00dd4841aba9edde408f141462396ce/src/common.jl#L40) is the main culprit:

```
$ ~/src/julia/julia perf.jl ~/Downloads/archlinux-2015.08.01-dual.iso
read:      0.443357 seconds (15 allocations: 657.001 MB)
SHA-1:     7.899572 seconds (43.06 M allocations: 3.048 GB, 1.71% gc time)
SHA-256:  11.636706 seconds (43.06 M allocations: 3.048 GB, 1.25% gc time)
SHA-512:   7.771521 seconds (21.53 M allocations: 2.246 GB, 1.63% gc time)
```