### PR TITLE
open(sha256, name) instead of "open(name) do ..."

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,7 @@ shell> cat /tmp/test.txt
 test
 julia> using SHA
 
-julia> open("/tmp/test.txt") do f
-           sha256(f)
-       end
+julia> open(sha256, "/tmp/test.txt")
 "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
 ```
 


### PR DESCRIPTION
The do x syntax is not necessary here as the block contains only one function call.