### PR TITLE
Use ⊻ instead of $ and bump Compat requirement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ os:
   - linux
   - osx
 julia:
-  - 0.3
   - 0.4
   - 0.5
   - nightly

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
 julia 0.3
-Compat 0.7.9
+Compat 0.9.4

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
-julia 0.3
+julia 0.4
 Compat 0.9.4

--- a/src/base_functions.jl
+++ b/src/base_functions.jl
@@ -25,16 +25,16 @@ Ch(x,y,z)  = ((x & y) ⊻ (~x & z))
 Maj(x,y,z) = ((x & y) ⊻ (x & z) ⊻ (y & z))
 
 # Four of six logical functions used in SHA-256:
-Sigma0_256(x) =   (S32(2,  @compat(UInt32(x))) ⊻ S32(13, @compat(UInt32(x))) ⊻ S32(22, @compat(UInt32(x))))
-Sigma1_256(x) =   (S32(6,  @compat(UInt32(x))) ⊻ S32(11, @compat(UInt32(x))) ⊻ S32(25, @compat(UInt32(x))))
-sigma0_256(x) =   (S32(7,  @compat(UInt32(x))) ⊻ S32(18, @compat(UInt32(x))) ⊻ R(3 ,   @compat(UInt32(x))))
-sigma1_256(x) =   (S32(17, @compat(UInt32(x))) ⊻ S32(19, @compat(UInt32(x))) ⊻ R(10,   @compat(UInt32(x))))
+Sigma0_256(x) =   (S32(2,  UInt32(x)) ⊻ S32(13, UInt32(x)) ⊻ S32(22, UInt32(x)))
+Sigma1_256(x) =   (S32(6,  UInt32(x)) ⊻ S32(11, UInt32(x)) ⊻ S32(25, UInt32(x)))
+sigma0_256(x) =   (S32(7,  UInt32(x)) ⊻ S32(18, UInt32(x)) ⊻ R(3 ,   UInt32(x)))
+sigma1_256(x) =   (S32(17, UInt32(x)) ⊻ S32(19, UInt32(x)) ⊻ R(10,   UInt32(x)))
 
 # Four of six logical functions used in SHA-384 and SHA-512:
-Sigma0_512(x) =   (S64(28, @compat(UInt64(x))) ⊻ S64(34, @compat(UInt64(x))) ⊻ S64(39, @compat(UInt64(x))))
-Sigma1_512(x) =   (S64(14, @compat(UInt64(x))) ⊻ S64(18, @compat(UInt64(x))) ⊻ S64(41, @compat(UInt64(x))))
-sigma0_512(x) =   (S64( 1, @compat(UInt64(x))) ⊻ S64( 8, @compat(UInt64(x))) ⊻ R( 7,   @compat(UInt64(x))))
-sigma1_512(x) =   (S64(19, @compat(UInt64(x))) ⊻ S64(61, @compat(UInt64(x))) ⊻ R( 6,   @compat(UInt64(x))))
+Sigma0_512(x) =   (S64(28, UInt64(x)) ⊻ S64(34, UInt64(x)) ⊻ S64(39, UInt64(x)))
+Sigma1_512(x) =   (S64(14, UInt64(x)) ⊻ S64(18, UInt64(x)) ⊻ S64(41, UInt64(x)))
+sigma0_512(x) =   (S64( 1, UInt64(x)) ⊻ S64( 8, UInt64(x)) ⊻ R( 7,   UInt64(x)))
+sigma1_512(x) =   (S64(19, UInt64(x)) ⊻ S64(61, UInt64(x)) ⊻ R( 6,   UInt64(x)))
 
 # Let's be able to bswap arrays of these types as well
 bswap!{T<:Integer}(x::Vector{T})  = map!(bswap, x)

--- a/src/base_functions.jl
+++ b/src/base_functions.jl
@@ -21,20 +21,20 @@ S64(b,x)        = rrot(b,x,64)
 L64(b,x)        = lrot(b,x,64)
 
 # Two of six logical functions used in SHA-256, SHA-384, and SHA-512:
-Ch(x,y,z)  = ((x & y) $ (~x & z))
-Maj(x,y,z) = ((x & y) $ (x & z) $ (y & z))
+Ch(x,y,z)  = ((x & y) ⊻ (~x & z))
+Maj(x,y,z) = ((x & y) ⊻ (x & z) ⊻ (y & z))
 
 # Four of six logical functions used in SHA-256:
-Sigma0_256(x) =   (S32(2,  @compat(UInt32(x))) $ S32(13, @compat(UInt32(x))) $ S32(22, @compat(UInt32(x))))
-Sigma1_256(x) =   (S32(6,  @compat(UInt32(x))) $ S32(11, @compat(UInt32(x))) $ S32(25, @compat(UInt32(x))))
-sigma0_256(x) =   (S32(7,  @compat(UInt32(x))) $ S32(18, @compat(UInt32(x))) $ R(3 ,   @compat(UInt32(x))))
-sigma1_256(x) =   (S32(17, @compat(UInt32(x))) $ S32(19, @compat(UInt32(x))) $ R(10,   @compat(UInt32(x))))
+Sigma0_256(x) =   (S32(2,  @compat(UInt32(x))) ⊻ S32(13, @compat(UInt32(x))) ⊻ S32(22, @compat(UInt32(x))))
+Sigma1_256(x) =   (S32(6,  @compat(UInt32(x))) ⊻ S32(11, @compat(UInt32(x))) ⊻ S32(25, @compat(UInt32(x))))
+sigma0_256(x) =   (S32(7,  @compat(UInt32(x))) ⊻ S32(18, @compat(UInt32(x))) ⊻ R(3 ,   @compat(UInt32(x))))
+sigma1_256(x) =   (S32(17, @compat(UInt32(x))) ⊻ S32(19, @compat(UInt32(x))) ⊻ R(10,   @compat(UInt32(x))))
 
 # Four of six logical functions used in SHA-384 and SHA-512:
-Sigma0_512(x) =   (S64(28, @compat(UInt64(x))) $ S64(34, @compat(UInt64(x))) $ S64(39, @compat(UInt64(x))))
-Sigma1_512(x) =   (S64(14, @compat(UInt64(x))) $ S64(18, @compat(UInt64(x))) $ S64(41, @compat(UInt64(x))))
-sigma0_512(x) =   (S64( 1, @compat(UInt64(x))) $ S64( 8, @compat(UInt64(x))) $ R( 7,   @compat(UInt64(x))))
-sigma1_512(x) =   (S64(19, @compat(UInt64(x))) $ S64(61, @compat(UInt64(x))) $ R( 6,   @compat(UInt64(x))))
+Sigma0_512(x) =   (S64(28, @compat(UInt64(x))) ⊻ S64(34, @compat(UInt64(x))) ⊻ S64(39, @compat(UInt64(x))))
+Sigma1_512(x) =   (S64(14, @compat(UInt64(x))) ⊻ S64(18, @compat(UInt64(x))) ⊻ S64(41, @compat(UInt64(x))))
+sigma0_512(x) =   (S64( 1, @compat(UInt64(x))) ⊻ S64( 8, @compat(UInt64(x))) ⊻ R( 7,   @compat(UInt64(x))))
+sigma1_512(x) =   (S64(19, @compat(UInt64(x))) ⊻ S64(61, @compat(UInt64(x))) ⊻ R( 6,   @compat(UInt64(x))))
 
 # Let's be able to bswap arrays of these types as well
 bswap!{T<:Integer}(x::Vector{T})  = map!(bswap, x)

--- a/src/common.jl
+++ b/src/common.jl
@@ -2,7 +2,7 @@
 
 # update! takes in variable-length data, buffering it into blocklen()-sized pieces,
 # calling transform!() when necessary to update the internal hash state.
-function update!{T<:@compat(Union{SHA1_CTX,SHA2_CTX,SHA3_CTX})}(context::T, data::Array{UInt8,1})
+function update!{T<:Union{SHA1_CTX,SHA2_CTX,SHA3_CTX}}(context::T, data::Array{UInt8,1})
     # We need to do all our arithmetic in the proper bitwidth
     UIntXXX = typeof(context.bytecount)
 
@@ -33,7 +33,7 @@ end
 
 
 # Clear out any saved data in the buffer, append total bitlength, and return our precious hash!
-function digest!{T<:@compat(Union{SHA1_CTX,SHA2_CTX})}(context::T)
+function digest!{T<:Union{SHA1_CTX,SHA2_CTX}}(context::T)
     usedspace = context.bytecount % blocklen(T)
     # If we have anything in the buffer still, pad and transform that data
     if usedspace > 0

--- a/src/sha1.jl
+++ b/src/sha1.jl
@@ -1,14 +1,14 @@
 # Nonlinear functions, in order to encourage inlining, these sadly are not an array of lambdas
 function Round0(b,c,d)
-    return @compat(UInt32((b & c) | (~b & d)))
+    return UInt32((b & c) | (~b & d))
 end
 
 function Round1And3(b,c,d)
-    return @compat(UInt32(b ⊻ c ⊻ d))
+    return UInt32(b ⊻ c ⊻ d)
 end
 
 function Round2(b,c,d)
-    return @compat(UInt32((b & c) | (b & d) | (c & d)))
+    return UInt32((b & c) | (b & d) | (c & d))
 end
 
 function transform!(context::SHA1_CTX)
@@ -43,7 +43,7 @@ function transform!(context::SHA1_CTX)
     # really kills performance and causes a huge number of allocations, so we make it easy on the compiler
     for i = 1:20
         @inbounds begin
-            temp = @compat(UInt32(lrot(5, a, 32) + Round0(b,c,d) + e + context.W[i] + K1[1]))
+            temp = UInt32(lrot(5, a, 32) + Round0(b,c,d) + e + context.W[i] + K1[1])
             e = d
             d = c
             c = lrot(30, b, 32)
@@ -54,7 +54,7 @@ function transform!(context::SHA1_CTX)
 
     for i = 21:40
         @inbounds begin
-            temp = @compat(UInt32(lrot(5, a, 32) + Round1And3(b,c,d) + e + context.W[i] + K1[2]))
+            temp = UInt32(lrot(5, a, 32) + Round1And3(b,c,d) + e + context.W[i] + K1[2])
             e = d
             d = c
             c = lrot(30, b, 32)
@@ -65,7 +65,7 @@ function transform!(context::SHA1_CTX)
 
     for i = 41:60
         @inbounds begin
-            temp = @compat(UInt32(lrot(5, a, 32) + Round2(b,c,d) + e + context.W[i] + K1[3]))
+            temp = UInt32(lrot(5, a, 32) + Round2(b,c,d) + e + context.W[i] + K1[3])
             e = d
             d = c
             c = lrot(30, b, 32)
@@ -76,7 +76,7 @@ function transform!(context::SHA1_CTX)
 
     for i = 61:80
         @inbounds begin
-            temp = @compat(UInt32(lrot(5, a, 32) + Round1And3(b,c,d) + e + context.W[i] + K1[4]))
+            temp = UInt32(lrot(5, a, 32) + Round1And3(b,c,d) + e + context.W[i] + K1[4])
             e = d
             d = c
             c = lrot(30, b, 32)

--- a/src/sha1.jl
+++ b/src/sha1.jl
@@ -4,7 +4,7 @@ function Round0(b,c,d)
 end
 
 function Round1And3(b,c,d)
-    return @compat(UInt32(b $ c $ d))
+    return @compat(UInt32(b ⊻ c ⊻ d))
 end
 
 function Round2(b,c,d)
@@ -21,14 +21,14 @@ function transform!(context::SHA1_CTX)
     # First round of expansions
     for i in 17:32
         @inbounds begin
-            context.W[i] = lrot(1, context.W[i-3] $ context.W[i-8] $ context.W[i-14] $ context.W[i-16], 32)
+            context.W[i] = lrot(1, context.W[i-3] ⊻ context.W[i-8] ⊻ context.W[i-14] ⊻ context.W[i-16], 32)
         end
     end
 
     # Second round of expansions (possibly 4-way SIMD-able)
     for i in 33:80
         @inbounds begin
-            context.W[i] = lrot(2, context.W[i-6] $ context.W[i-16] $ context.W[i-28] $ context.W[i-32], 32)
+            context.W[i] = lrot(2, context.W[i-6] ⊻ context.W[i-16] ⊻ context.W[i-28] ⊻ context.W[i-32], 32)
         end
     end
 

--- a/src/sha2.jl
+++ b/src/sha2.jl
@@ -1,4 +1,4 @@
-function transform!{T<:@compat(Union{SHA2_224_CTX,SHA2_256_CTX})}(context::T)
+function transform!{T<:Union{SHA2_224_CTX,SHA2_256_CTX}}(context::T)
     buffer = reinterpret(eltype(context.state), context.buffer)
     # Initialize registers with the previous intermediate values (our state)
     a = context.state[1]
@@ -22,11 +22,11 @@ function transform!{T<:@compat(Union{SHA2_224_CTX,SHA2_256_CTX})}(context::T)
             h = g
             g = f
             f = e
-            e = @compat UInt32(d + T1)
+            e = UInt32(d + T1)
             d = c
             c = b
             b = a
-            a = @compat UInt32(T1 + T2)
+            a = UInt32(T1 + T2)
         end
     end
 
@@ -45,11 +45,11 @@ function transform!{T<:@compat(Union{SHA2_224_CTX,SHA2_256_CTX})}(context::T)
             h = g
             g = f
             f = e
-            e = @compat UInt32(d + T1)
+            e = UInt32(d + T1)
             d = c
             c = b
             b = a
-            a = @compat UInt32(T1 + T2)
+            a = UInt32(T1 + T2)
         end
     end
 
@@ -65,7 +65,7 @@ function transform!{T<:@compat(Union{SHA2_224_CTX,SHA2_256_CTX})}(context::T)
 end
 
 
-function transform!(context::@compat(Union{SHA2_384_CTX,SHA2_512_CTX}))
+function transform!(context::Union{SHA2_384_CTX,SHA2_512_CTX})
     buffer = reinterpret(eltype(context.state), context.buffer)
     # Initialize registers with the prev. intermediate value
     a = context.state[1]

--- a/src/sha3.jl
+++ b/src/sha3.jl
@@ -2,7 +2,7 @@ function transform!{T<:SHA3_CTX}(context::T)
     # First, update state with buffer
     buffer_as_uint64 = reinterpret(eltype(context.state), context.buffer)
     for idx in 1:div(blocklen(T),8)
-        context.state[idx] $= buffer_as_uint64[idx]
+        context.state[idx] = context.state[idx] ⊻ buffer_as_uint64[idx]
     end
     bc = Array(UInt64, 5)
 
@@ -10,13 +10,13 @@ function transform!{T<:SHA3_CTX}(context::T)
     for round in 0:23
         # Theta function
         for i in 1:5
-            bc[i] = context.state[i] $ context.state[i + 5] $ context.state[i + 10] $ context.state[i + 15] $ context.state[i + 20]
+            bc[i] = context.state[i] ⊻ context.state[i + 5] ⊻ context.state[i + 10] ⊻ context.state[i + 15] ⊻ context.state[i + 20]
         end
 
         for i in 1:5
-            temp = bc[mod1(i + 4, 5)] $ L64(1, bc[mod1(i + 1, 5)])
+            temp = bc[mod1(i + 4, 5)] ⊻ L64(1, bc[mod1(i + 1, 5)])
             for j in 0:5:20
-                context.state[i + j] $= temp
+                context.state[i + j] = context.state[i + j] ⊻ temp
             end
         end
 
@@ -35,12 +35,12 @@ function transform!{T<:SHA3_CTX}(context::T)
                 bc[i] = context.state[i + j]
             end
             for i in 1:5
-                context.state[j + i] $= (~bc[mod1(i + 1, 5)] & bc[mod1(i + 2, 5)])
+                context.state[j + i] = context.state[j + i] ⊻ (~bc[mod1(i + 1, 5)] & bc[mod1(i + 2, 5)])
             end
         end
 
         # Iota
-        context.state[1] $= SHA3_ROUND_CONSTS[round+1]
+        context.state[1] = context.state[1] ⊻ SHA3_ROUND_CONSTS[round+1]
     end
 
     return context.state

--- a/src/types.jl
+++ b/src/types.jl
@@ -89,20 +89,20 @@ state_type(::Type{SHA2_384_CTX}) = UInt64
 state_type(::Type{SHA2_512_CTX}) = UInt64
 
 # blocklen is the number of bytes of data processed by the transform!() function at once
-blocklen(::Type{SHA1_CTX}) = @compat UInt64(64)
-blocklen(::Type{SHA2_224_CTX}) = @compat UInt64(64)
-blocklen(::Type{SHA2_256_CTX}) = @compat UInt64(64)
-blocklen(::Type{SHA2_384_CTX}) = @compat UInt64(128)
-blocklen(::Type{SHA2_512_CTX}) = @compat UInt64(128)
+blocklen(::Type{SHA1_CTX}) = UInt64(64)
+blocklen(::Type{SHA2_224_CTX}) = UInt64(64)
+blocklen(::Type{SHA2_256_CTX}) = UInt64(64)
+blocklen(::Type{SHA2_384_CTX}) = UInt64(128)
+blocklen(::Type{SHA2_512_CTX}) = UInt64(128)
 
-blocklen(::Type{SHA3_224_CTX}) = @compat UInt64(25*8 - 2*digestlen(SHA3_224_CTX))
-blocklen(::Type{SHA3_256_CTX}) = @compat UInt64(25*8 - 2*digestlen(SHA3_256_CTX))
-blocklen(::Type{SHA3_384_CTX}) = @compat UInt64(25*8 - 2*digestlen(SHA3_384_CTX))
-blocklen(::Type{SHA3_512_CTX}) = @compat UInt64(25*8 - 2*digestlen(SHA3_512_CTX))
+blocklen(::Type{SHA3_224_CTX}) = UInt64(25*8 - 2*digestlen(SHA3_224_CTX))
+blocklen(::Type{SHA3_256_CTX}) = UInt64(25*8 - 2*digestlen(SHA3_256_CTX))
+blocklen(::Type{SHA3_384_CTX}) = UInt64(25*8 - 2*digestlen(SHA3_384_CTX))
+blocklen(::Type{SHA3_512_CTX}) = UInt64(25*8 - 2*digestlen(SHA3_512_CTX))
 
 
 # short_blocklen is the size of a block minus the width of bytecount
-short_blocklen{T<:@compat(Union{SHA1_CTX,SHA2_CTX})}(::Type{T}) = blocklen(T) - 2*sizeof(state_type(T))
+short_blocklen{T<:Union{SHA1_CTX,SHA2_CTX}}(::Type{T}) = blocklen(T) - 2*sizeof(state_type(T))
 
 # Once the "blocklen" methods are defined, we can define our outer constructors for SHA types:
 SHA2_224_CTX() = SHA2_224_CTX(copy(SHA2_224_initial_hash_value), 0, zeros(UInt8, blocklen(SHA2_224_CTX)))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,7 +12,7 @@ data = Any["", "test", lorem, file, so_many_as]
 
 # Descriptions of the data, the SHA functions we'll run on the data, etc...
 data_desc = ["the empty string", "the string \"test\"", "lorem ipsum", "0 file", "one million a's"]
-sha_types = @compat Dict(sha1 => SHA.SHA1_CTX,
+sha_types = Dict(sha1 => SHA.SHA1_CTX,
             sha2_224 => SHA.SHA2_224_CTX, sha2_256 => SHA.SHA2_256_CTX, sha2_384 => SHA.SHA2_384_CTX, sha2_512 => SHA.SHA2_512_CTX,
             sha3_224 => SHA.SHA3_224_CTX, sha3_256 => SHA.SHA3_256_CTX, sha3_384 => SHA.SHA3_384_CTX, sha3_512 => SHA.SHA3_512_CTX)
 sha_funcs = [sha1,
@@ -25,7 +25,7 @@ shws = ["SHA1 hash state",
         "SHA2 224-bit hash state", "SHA2 256-bit hash state", "SHA2 384-bit hash state", "SHA2 512-bit hash state",
         "SHA3 224-bit hash state", "SHA3 256-bit hash state", "SHA3 384-bit hash state", "SHA3 512-bit hash state"]
 
-answers = @compat Dict(
+answers = Dict(
 sha1 => [
 "da39a3ee5e6b4b0d3255bfef95601890afd80709",
 "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",


### PR DESCRIPTION
`@staticfloat`, `$` is deprecated so here is an update. I've bumped the version requirement so this PR should wait for https://github.com/JuliaLang/METADATA.jl/pull/7038
