### PR TITLE
Remove 0.3 support and accommodate 0.6 changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ os:
   - linux
   - osx
 julia:
-  - 0.3
   - 0.4
   - 0.5
   - nightly

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![Build Status](https://travis-ci.org/staticfloat/SHA.jl.svg?branch=master)](https://travis-ci.org/staticfloat/SHA.jl)
 [![codecov.io](http://codecov.io/github/staticfloat/SHA.jl/coverage.svg?branch=master)](http://codecov.io/github/staticfloat/SHA.jl?branch=master)
 
-[![SHA](http://pkg.julialang.org/badges/SHA_0.3.svg)](http://pkg.julialang.org/?pkg=SHA&ver=0.3)
 [![SHA](http://pkg.julialang.org/badges/SHA_0.4.svg)](http://pkg.julialang.org/?pkg=SHA&ver=0.4)
 
 Usage is very straightforward:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@
 [![Build Status](https://travis-ci.org/staticfloat/SHA.jl.svg?branch=master)](https://travis-ci.org/staticfloat/SHA.jl)
 [![codecov.io](http://codecov.io/github/staticfloat/SHA.jl/coverage.svg?branch=master)](http://codecov.io/github/staticfloat/SHA.jl?branch=master)
 
-[![SHA](http://pkg.julialang.org/badges/SHA_0.4.svg)](http://pkg.julialang.org/?pkg=SHA&ver=0.4)
+[![SHA](http://pkg.julialang.org/badges/SHA_0.4.svg)](http://pkg.julialang.org/?pkg=SHA)
+[![SHA](http://pkg.julialang.org/badges/SHA_0.5.svg)](http://pkg.julialang.org/?pkg=SHA)
+[![SHA](http://pkg.julialang.org/badges/SHA_0.6.svg)](http://pkg.julialang.org/?pkg=SHA)
 
 Usage is very straightforward:
 ```

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
 julia 0.4
-Compat 0.7.9
+Compat 0.9.4

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
-julia 0.3
+julia 0.4
 Compat 0.7.9

--- a/src/base_functions.jl
+++ b/src/base_functions.jl
@@ -21,20 +21,20 @@ S64(b,x)        = rrot(b,x,64)
 L64(b,x)        = lrot(b,x,64)
 
 # Two of six logical functions used in SHA-256, SHA-384, and SHA-512:
-Ch(x,y,z)  = ((x & y) $ (~x & z))
-Maj(x,y,z) = ((x & y) $ (x & z) $ (y & z))
+Ch(x,y,z)  = ((x & y) ⊻ (~x & z))
+Maj(x,y,z) = ((x & y) ⊻ (x & z) ⊻ (y & z))
 
 # Four of six logical functions used in SHA-256:
-Sigma0_256(x) =   (S32(2,  @compat(UInt32(x))) $ S32(13, @compat(UInt32(x))) $ S32(22, @compat(UInt32(x))))
-Sigma1_256(x) =   (S32(6,  @compat(UInt32(x))) $ S32(11, @compat(UInt32(x))) $ S32(25, @compat(UInt32(x))))
-sigma0_256(x) =   (S32(7,  @compat(UInt32(x))) $ S32(18, @compat(UInt32(x))) $ R(3 ,   @compat(UInt32(x))))
-sigma1_256(x) =   (S32(17, @compat(UInt32(x))) $ S32(19, @compat(UInt32(x))) $ R(10,   @compat(UInt32(x))))
+Sigma0_256(x) =   (S32(2,  @compat(UInt32(x))) ⊻ S32(13, @compat(UInt32(x))) ⊻ S32(22, @compat(UInt32(x))))
+Sigma1_256(x) =   (S32(6,  @compat(UInt32(x))) ⊻ S32(11, @compat(UInt32(x))) ⊻ S32(25, @compat(UInt32(x))))
+sigma0_256(x) =   (S32(7,  @compat(UInt32(x))) ⊻ S32(18, @compat(UInt32(x))) ⊻ R(3 ,   @compat(UInt32(x))))
+sigma1_256(x) =   (S32(17, @compat(UInt32(x))) ⊻ S32(19, @compat(UInt32(x))) ⊻ R(10,   @compat(UInt32(x))))
 
 # Four of six logical functions used in SHA-384 and SHA-512:
-Sigma0_512(x) =   (S64(28, @compat(UInt64(x))) $ S64(34, @compat(UInt64(x))) $ S64(39, @compat(UInt64(x))))
-Sigma1_512(x) =   (S64(14, @compat(UInt64(x))) $ S64(18, @compat(UInt64(x))) $ S64(41, @compat(UInt64(x))))
-sigma0_512(x) =   (S64( 1, @compat(UInt64(x))) $ S64( 8, @compat(UInt64(x))) $ R( 7,   @compat(UInt64(x))))
-sigma1_512(x) =   (S64(19, @compat(UInt64(x))) $ S64(61, @compat(UInt64(x))) $ R( 6,   @compat(UInt64(x))))
+Sigma0_512(x) =   (S64(28, @compat(UInt64(x))) ⊻ S64(34, @compat(UInt64(x))) ⊻ S64(39, @compat(UInt64(x))))
+Sigma1_512(x) =   (S64(14, @compat(UInt64(x))) ⊻ S64(18, @compat(UInt64(x))) ⊻ S64(41, @compat(UInt64(x))))
+sigma0_512(x) =   (S64( 1, @compat(UInt64(x))) ⊻ S64( 8, @compat(UInt64(x))) ⊻ R( 7,   @compat(UInt64(x))))
+sigma1_512(x) =   (S64(19, @compat(UInt64(x))) ⊻ S64(61, @compat(UInt64(x))) ⊻ R( 6,   @compat(UInt64(x))))
 
 # Let's be able to bswap arrays of these types as well
 bswap!{T<:Integer}(x::Vector{T})  = map!(bswap, x)

--- a/src/sha1.jl
+++ b/src/sha1.jl
@@ -4,7 +4,7 @@ function Round0(b,c,d)
 end
 
 function Round1And3(b,c,d)
-    return @compat(UInt32(b $ c $ d))
+    return @compat(UInt32(b ⊻ c ⊻ d))
 end
 
 function Round2(b,c,d)
@@ -21,14 +21,14 @@ function transform!(context::SHA1_CTX)
     # First round of expansions
     for i in 17:32
         @inbounds begin
-            context.W[i] = lrot(1, context.W[i-3] $ context.W[i-8] $ context.W[i-14] $ context.W[i-16], 32)
+            context.W[i] = lrot(1, context.W[i-3] ⊻ context.W[i-8] ⊻ context.W[i-14] ⊻ context.W[i-16], 32)
         end
     end
 
     # Second round of expansions (possibly 4-way SIMD-able)
     for i in 33:80
         @inbounds begin
-            context.W[i] = lrot(2, context.W[i-6] $ context.W[i-16] $ context.W[i-28] $ context.W[i-32], 32)
+            context.W[i] = lrot(2, context.W[i-6] ⊻ context.W[i-16] ⊻ context.W[i-28] ⊻ context.W[i-32], 32)
         end
     end
 

--- a/src/sha3.jl
+++ b/src/sha3.jl
@@ -2,21 +2,21 @@ function transform!{T<:SHA3_CTX}(context::T)
     # First, update state with buffer
     buffer_as_uint64 = reinterpret(eltype(context.state), context.buffer)
     for idx in 1:div(blocklen(T),8)
-        context.state[idx] $= buffer_as_uint64[idx]
+        context.state[idx] = context.state[idx] ⊻ buffer_as_uint64[idx]
     end
-    bc = Array(UInt64, 5)
+    bc = Array{UInt64}(5)
 
     # We always assume 24 rounds
     for round in 0:23
         # Theta function
         for i in 1:5
-            bc[i] = context.state[i] $ context.state[i + 5] $ context.state[i + 10] $ context.state[i + 15] $ context.state[i + 20]
+            bc[i] = context.state[i] ⊻ context.state[i + 5] ⊻ context.state[i + 10] ⊻ context.state[i + 15] ⊻ context.state[i + 20]
         end
 
         for i in 1:5
-            temp = bc[mod1(i + 4, 5)] $ L64(1, bc[mod1(i + 1, 5)])
+            temp = bc[mod1(i + 4, 5)] ⊻ L64(1, bc[mod1(i + 1, 5)])
             for j in 0:5:20
-                context.state[i + j] $= temp
+                context.state[i + j] = context.state[i + j] ⊻ temp
             end
         end
 
@@ -35,12 +35,12 @@ function transform!{T<:SHA3_CTX}(context::T)
                 bc[i] = context.state[i + j]
             end
             for i in 1:5
-                context.state[j + i] $= (~bc[mod1(i + 1, 5)] & bc[mod1(i + 2, 5)])
+                context.state[j + i] = context.state[j + i] ⊻ (~bc[mod1(i + 1, 5)] & bc[mod1(i + 2, 5)])
             end
         end
 
         # Iota
-        context.state[1] $= SHA3_ROUND_CONSTS[round+1]
+        context.state[1] = context.state[1] ⊻ SHA3_ROUND_CONSTS[round+1]
     end
 
     return context.state


### PR DESCRIPTION
This PR drops support for Julia 0.3, which will have to be removed anyway for this package to have another tag registered in METADATA. It also accommodates the deprecation in Julia 0.6 of infix `$` for XOR. As an added bonus I stuck the 0.5 and 0.6 PkgEval badges in the README.

The commits are intended to be easily separable so that if any change here is controversial, it can be removed from the PR easily.

cc @staticfloat 