### PR TITLE
Update dep map! method

### DIFF
--- a/src/base_functions.jl
+++ b/src/base_functions.jl
@@ -37,4 +37,4 @@ sigma0_512(x) =   (S64( 1, UInt64(x)) ⊻ S64( 8, UInt64(x)) ⊻ R( 7,   UInt64(
 sigma1_512(x) =   (S64(19, UInt64(x)) ⊻ S64(61, UInt64(x)) ⊻ R( 6,   UInt64(x)))
 
 # Let's be able to bswap arrays of these types as well
-bswap!{T<:Integer}(x::Vector{T})  = map!(bswap, x)
+bswap!{T<:Integer}(x::Vector{T})  = map!(bswap, x, x)


### PR DESCRIPTION
Remove final depwarn
`Testing on one million a's (chunked properly)WARNING: map!{F}(f::F, A::AbstractArray) is deprecated, use map!(f, A, A) instead.`

@staticfloat

