### PR TITLE
hashing tuples

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,7 @@ os:
   - linux
   - osx
 julia:
-  - 0.4
-  - 0.5
+  - 0.6
   - nightly
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![SHA](http://pkg.julialang.org/badges/SHA_0.4.svg)](http://pkg.julialang.org/?pkg=SHA&ver=0.4)
 
 Usage is very straightforward:
-```
+```julia
 julia> using SHA
 
 julia> bytes2hex(sha256("test"))
@@ -16,7 +16,7 @@ julia> bytes2hex(sha256("test"))
 
 Each exported function (at the time of this writing, SHA-1, SHA-2 224, 256, 384 and 512, and SHA-3 224, 256, 384 and 512 functions are implemented) takes in either an `Array{UInt8}`, a `ByteString` or an `IO` object.  This makes it trivial to checksum a file:
 
-```
+```julia
 shell> cat /tmp/test.txt
 test
 julia> using SHA

--- a/README.md
+++ b/README.md
@@ -47,4 +47,6 @@ Note the lack of a newline at the end of `/tmp/text.txt`.  Julia automatically i
 
 Due to the colloquial usage of `sha256` to refer to `sha2_256`, convenience functions are provided, mapping `shaxxx()` function calls to `sha2_xxx()`.  For SHA-3, no such colloquialisms exist and the user must use the full `sha3_xxx()` names.
 
+`shaxxx()` takes `AbstractString` and array-like objects (`NTuple` and `Array`) with elements of type `UInt8`.
+
 Note that, at the time of this writing, the SHA3 code is not optimized, and as such is roughly an order of magnitude slower than SHA2.  Pull requests are welcome.

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
-julia 0.4
+julia 0.6
 Compat 0.17.0

--- a/src/SHA.jl
+++ b/src/SHA.jl
@@ -1,4 +1,4 @@
-isdefined(Base, :__precompile__) && __precompile__()
+__precompile__()
 
 module SHA
 

--- a/src/SHA.jl
+++ b/src/SHA.jl
@@ -45,7 +45,7 @@ for (f, ctx) in [(:sha1, :SHA1_CTX),
         end
 
         # AbstractStrings are a pretty handy thing to be able to crunch through
-        $f(str::AbstractString) = $f(convert(Array{UInt8,1}, str))
+        $f(str::AbstractString) = $f(Vector{UInt8}(str))
 
         # Convenience function for IO devices, allows for things like:
         # open("test.txt") do f

--- a/src/SHA.jl
+++ b/src/SHA.jl
@@ -38,8 +38,7 @@ for (f, ctx) in [(:sha1, :SHA1_CTX),
                  (:sha3_512, :SHA3_512_CTX),]
     @eval begin
         # Our basic function is to process arrays of bytes
-        function $f(data)
-            @assert eltype(data) == UInt8
+        function $f(data::T) where T<:Union{Array{UInt8,1},NTuple{N,UInt8} where N}
             ctx = $ctx()
             update!(ctx, data)
             return digest!(ctx)

--- a/src/SHA.jl
+++ b/src/SHA.jl
@@ -38,7 +38,7 @@ for (f, ctx) in [(:sha1, :SHA1_CTX),
                  (:sha3_512, :SHA3_512_CTX),]
     @eval begin
         # Our basic function is to process arrays of bytes
-        function $f(data::Array{UInt8,1})
+        function $f{N}(data::Union{Array{UInt8, N}, NTuple{N, UInt8}})
             ctx = $ctx()
             update!(ctx, data)
             return digest!(ctx)

--- a/src/SHA.jl
+++ b/src/SHA.jl
@@ -38,7 +38,8 @@ for (f, ctx) in [(:sha1, :SHA1_CTX),
                  (:sha3_512, :SHA3_512_CTX),]
     @eval begin
         # Our basic function is to process arrays of bytes
-        function $f{N}(data::Union{Array{UInt8, N}, NTuple{N, UInt8}})
+        function $f(data)
+            @assert eltype(data) == UInt8
             ctx = $ctx()
             update!(ctx, data)
             return digest!(ctx)

--- a/src/base_functions.jl
+++ b/src/base_functions.jl
@@ -37,4 +37,4 @@ sigma0_512(x) =   (S64( 1, UInt64(x)) ⊻ S64( 8, UInt64(x)) ⊻ R( 7,   UInt64(
 sigma1_512(x) =   (S64(19, UInt64(x)) ⊻ S64(61, UInt64(x)) ⊻ R( 6,   UInt64(x)))
 
 # Let's be able to bswap arrays of these types as well
-bswap!{T<:Integer}(x::Vector{T})  = map!(bswap, x, x)
+bswap!(x::Vector{<:Integer}) = map!(bswap, x, x)

--- a/src/base_functions.jl
+++ b/src/base_functions.jl
@@ -12,29 +12,29 @@ rrot(b,x,width) = ((x >> b) | (x << (width - b)))
 lrot(b,x,width) = ((x << b) | (x >> (width - b)))
 
 # Shift-right (used in SHA-256, SHA-384, and SHA-512):
-R(b,x)          = (x >> b)
+R(b,x)   = (x >> b)
 # 32-bit Rotate-right (used in SHA-256):
-S32(b,x)        = rrot(b,x,32)
+S32(b,x) = rrot(b,x,32)
 # 64-bit Rotate-right (used in SHA-384 and SHA-512):
-S64(b,x)        = rrot(b,x,64)
+S64(b,x) = rrot(b,x,64)
 # 64-bit Rotate-left (used in SHA3)
-L64(b,x)        = lrot(b,x,64)
+L64(b,x) = lrot(b,x,64)
 
 # Two of six logical functions used in SHA-256, SHA-384, and SHA-512:
 Ch(x,y,z)  = ((x & y) ⊻ (~x & z))
 Maj(x,y,z) = ((x & y) ⊻ (x & z) ⊻ (y & z))
 
 # Four of six logical functions used in SHA-256:
-Sigma0_256(x) =   (S32(2,  UInt32(x)) ⊻ S32(13, UInt32(x)) ⊻ S32(22, UInt32(x)))
-Sigma1_256(x) =   (S32(6,  UInt32(x)) ⊻ S32(11, UInt32(x)) ⊻ S32(25, UInt32(x)))
-sigma0_256(x) =   (S32(7,  UInt32(x)) ⊻ S32(18, UInt32(x)) ⊻ R(3 ,   UInt32(x)))
-sigma1_256(x) =   (S32(17, UInt32(x)) ⊻ S32(19, UInt32(x)) ⊻ R(10,   UInt32(x)))
+Sigma0_256(x) = (S32(2,  UInt32(x)) ⊻ S32(13, UInt32(x)) ⊻ S32(22, UInt32(x)))
+Sigma1_256(x) = (S32(6,  UInt32(x)) ⊻ S32(11, UInt32(x)) ⊻ S32(25, UInt32(x)))
+sigma0_256(x) = (S32(7,  UInt32(x)) ⊻ S32(18, UInt32(x)) ⊻ R(3 ,   UInt32(x)))
+sigma1_256(x) = (S32(17, UInt32(x)) ⊻ S32(19, UInt32(x)) ⊻ R(10,   UInt32(x)))
 
 # Four of six logical functions used in SHA-384 and SHA-512:
-Sigma0_512(x) =   (S64(28, UInt64(x)) ⊻ S64(34, UInt64(x)) ⊻ S64(39, UInt64(x)))
-Sigma1_512(x) =   (S64(14, UInt64(x)) ⊻ S64(18, UInt64(x)) ⊻ S64(41, UInt64(x)))
-sigma0_512(x) =   (S64( 1, UInt64(x)) ⊻ S64( 8, UInt64(x)) ⊻ R( 7,   UInt64(x)))
-sigma1_512(x) =   (S64(19, UInt64(x)) ⊻ S64(61, UInt64(x)) ⊻ R( 6,   UInt64(x)))
+Sigma0_512(x) = (S64(28, UInt64(x)) ⊻ S64(34, UInt64(x)) ⊻ S64(39, UInt64(x)))
+Sigma1_512(x) = (S64(14, UInt64(x)) ⊻ S64(18, UInt64(x)) ⊻ S64(41, UInt64(x)))
+sigma0_512(x) = (S64( 1, UInt64(x)) ⊻ S64( 8, UInt64(x)) ⊻ R( 7,   UInt64(x)))
+sigma1_512(x) = (S64(19, UInt64(x)) ⊻ S64(61, UInt64(x)) ⊻ R( 6,   UInt64(x)))
 
 # Let's be able to bswap arrays of these types as well
 bswap!(x::Vector{<:Integer}) = map!(bswap, x, x)

--- a/src/common.jl
+++ b/src/common.jl
@@ -2,7 +2,7 @@
 
 # update! takes in variable-length data, buffering it into blocklen()-sized pieces,
 # calling transform!() when necessary to update the internal hash state.
-function update!{T<:Union{SHA1_CTX,SHA2_CTX,SHA3_CTX}}(context::T, data::Array{UInt8,1})
+function update!(context::T, data::Array{UInt8,1}) where {T<:Union{SHA1_CTX,SHA2_CTX,SHA3_CTX}}
     # We need to do all our arithmetic in the proper bitwidth
     UIntXXX = typeof(context.bytecount)
 
@@ -33,7 +33,7 @@ end
 
 
 # Clear out any saved data in the buffer, append total bitlength, and return our precious hash!
-function digest!{T<:Union{SHA1_CTX,SHA2_CTX}}(context::T)
+function digest!(context::T) where {T<:Union{SHA1_CTX,SHA2_CTX}}
     usedspace = context.bytecount % blocklen(T)
     # If we have anything in the buffer still, pad and transform that data
     if usedspace > 0

--- a/src/common.jl
+++ b/src/common.jl
@@ -65,9 +65,9 @@ function digest!{T<:Union{SHA1_CTX,SHA2_CTX}}(context::T)
     end
 
     # Store the length of the input data (in bits) at the end of the padding
-    bitcount_buffer = reinterpret(typeof(context.bytecount), context.buffer)
-    bitcount_idx = div(short_blocklen(T), sizeof(context.bytecount))+1
-    bitcount_buffer[bitcount_idx] = bswap(context.bytecount*8)
+    bitcount_idx = div(short_blocklen(T), sizeof(context.bytecount)) + 1
+    pbuf = Ptr{typeof(context.bytecount)}(pointer(context.buffer))
+    unsafe_store!(pbuf, bswap(context.bytecount * 8), bitcount_idx)
 
     # Final transform:
     transform!(context)

--- a/src/common.jl
+++ b/src/common.jl
@@ -2,7 +2,8 @@
 
 # update! takes in variable-length data, buffering it into blocklen()-sized pieces,
 # calling transform!() when necessary to update the internal hash state.
-function update!(context::T, data::Array{UInt8,1}) where {T<:Union{SHA1_CTX,SHA2_CTX,SHA3_CTX}}
+function update!(context::T, data::U) where {T<:Union{SHA1_CTX,SHA2_CTX,SHA3_CTX},
+                                             U<:Union{Array{UInt8,1},NTuple{N,UInt8} where N}}
     # We need to do all our arithmetic in the proper bitwidth
     UIntXXX = typeof(context.bytecount)
 

--- a/src/sha1.jl
+++ b/src/sha1.jl
@@ -13,9 +13,9 @@ end
 
 function transform!(context::SHA1_CTX)
     # Buffer is 16 elements long, we expand to 80
-    buffer = reinterpret(eltype(context.state), context.buffer)
+    pbuf = Ptr{eltype(context.state)}(pointer(context.buffer))
     for i in 1:16
-        context.W[i] = bswap(buffer[i])
+        context.W[i] = bswap(unsafe_load(pbuf, i))
     end
 
     # First round of expansions

--- a/src/sha2.jl
+++ b/src/sha2.jl
@@ -1,4 +1,4 @@
-function transform!{T<:Union{SHA2_224_CTX,SHA2_256_CTX}}(context::T)
+function transform!(context::T) where {T<:Union{SHA2_224_CTX,SHA2_256_CTX}}
     pbuf = Ptr{eltype(context.state)}(pointer(context.buffer))
     # Initialize registers with the previous intermediate values (our state)
     a = context.state[1]

--- a/src/sha2.jl
+++ b/src/sha2.jl
@@ -1,5 +1,5 @@
 function transform!{T<:Union{SHA2_224_CTX,SHA2_256_CTX}}(context::T)
-    buffer = reinterpret(eltype(context.state), context.buffer)
+    pbuf = Ptr{eltype(context.state)}(pointer(context.buffer))
     # Initialize registers with the previous intermediate values (our state)
     a = context.state[1]
     b = context.state[2]
@@ -14,10 +14,11 @@ function transform!{T<:Union{SHA2_224_CTX,SHA2_256_CTX}}(context::T)
     for j = 1:16
         @inbounds begin
             # We bitswap every input byte
-            buffer[j] = bswap(buffer[j])
+            v = bswap(unsafe_load(pbuf, j))
+            unsafe_store!(pbuf, v, j)
 
             # Apply the SHA-256 compression function to update a..h
-            T1 = h + Sigma1_256(e) + Ch(e, f, g) + K256[j] + buffer[j]
+            T1 = h + Sigma1_256(e) + Ch(e, f, g) + K256[j] + v
             T2 = Sigma0_256(a) + Maj(a, b, c)
             h = g
             g = f
@@ -33,14 +34,15 @@ function transform!{T<:Union{SHA2_224_CTX,SHA2_256_CTX}}(context::T)
     for j = 17:64
         @inbounds begin
             # Implicit message block expansion:
-            s0 = buffer[mod1(j + 1, 16)]
+            s0 = unsafe_load(pbuf, mod1(j + 1, 16))
             s0 = sigma0_256(s0)
-            s1 = buffer[mod1(j + 14, 16)]
+            s1 = unsafe_load(pbuf, mod1(j + 14, 16))
             s1 = sigma1_256(s1)
 
             # Apply the SHA-256 compression function to update a..h
-            buffer[mod1(j, 16)] += s1 + buffer[mod1(j + 9,16)] + s0
-            T1 = h + Sigma1_256(e) + Ch(e, f, g) + K256[j] + buffer[mod1(j, 16)]
+            v = unsafe_load(pbuf, mod1(j, 16)) + s1 + unsafe_load(pbuf, mod1(j + 9, 16)) + s0
+            unsafe_store!(pbuf, v, mod1(j, 16))
+            T1 = h + Sigma1_256(e) + Ch(e, f, g) + K256[j] + v
             T2 = Sigma0_256(a) + Maj(a, b, c)
             h = g
             g = f
@@ -66,7 +68,7 @@ end
 
 
 function transform!(context::Union{SHA2_384_CTX,SHA2_512_CTX})
-    buffer = reinterpret(eltype(context.state), context.buffer)
+    pbuf = Ptr{eltype(context.state)}(pointer(context.buffer))
     # Initialize registers with the prev. intermediate value
     a = context.state[1]
     b = context.state[2]
@@ -79,10 +81,11 @@ function transform!(context::Union{SHA2_384_CTX,SHA2_512_CTX})
 
     for j = 1:16
         @inbounds begin
-            buffer[j] = bswap(buffer[j])
+            v = bswap(unsafe_load(pbuf, j))
+            unsafe_store!(pbuf, v, j)
 
             # Apply the SHA-512 compression function to update a..h
-            T1 = h + Sigma1_512(e) + Ch(e, f, g) + K512[j] + buffer[j]
+            T1 = h + Sigma1_512(e) + Ch(e, f, g) + K512[j] + v
             T2 = Sigma0_512(a) + Maj(a, b, c)
             h = g
             g = f
@@ -98,14 +101,15 @@ function transform!(context::Union{SHA2_384_CTX,SHA2_512_CTX})
     for j = 17:80
         @inbounds begin
             # Implicit message block expansion:
-            s0 = buffer[mod1(j + 1, 16)]
+            s0 = unsafe_load(pbuf, mod1(j + 1, 16))
             s0 = sigma0_512(s0)
-            s1 = buffer[mod1(j+14, 16)]
+            s1 = unsafe_load(pbuf, mod1(j + 14, 16))
             s1 = sigma1_512(s1)
 
             # Apply the SHA-512 compression function to update a..h
-            buffer[mod1(j, 16)] += s1 + buffer[mod1(j+9, 16)] + s0
-            T1 = h + Sigma1_512(e) + Ch(e, f, g) + K512[j] + buffer[mod1(j, 16)]
+            v = unsafe_load(pbuf, mod1(j, 16)) + s1 + unsafe_load(pbuf, mod1(j + 9, 16)) + s0
+            unsafe_store!(pbuf, v, mod1(j, 16))
+            T1 = h + Sigma1_512(e) + Ch(e, f, g) + K512[j] + v
             T2 = Sigma0_512(a) + Maj(a, b, c)
             h = g
             g = f

--- a/src/sha3.jl
+++ b/src/sha3.jl
@@ -1,4 +1,4 @@
-function transform!{T<:SHA3_CTX}(context::T)
+function transform!(context::T) where {T<:SHA3_CTX}
     # First, update state with buffer
     pbuf = Ptr{eltype(context.state)}(pointer(context.buffer))
     for idx in 1:div(blocklen(T),8)
@@ -49,7 +49,7 @@ end
 
 
 # Finalize data in the buffer, append total bitlength, and return our precious hash!
-function digest!{T<:SHA3_CTX}(context::T)
+function digest!(context::T) where {T<:SHA3_CTX}
     usedspace = context.bytecount % blocklen(T)
     # If we have anything in the buffer still, pad and transform that data
     if usedspace < blocklen(T) - 1

--- a/src/sha3.jl
+++ b/src/sha3.jl
@@ -1,8 +1,8 @@
 function transform!{T<:SHA3_CTX}(context::T)
     # First, update state with buffer
-    buffer_as_uint64 = reinterpret(eltype(context.state), context.buffer)
+    pbuf = Ptr{eltype(context.state)}(pointer(context.buffer))
     for idx in 1:div(blocklen(T),8)
-        context.state[idx] = context.state[idx] ⊻ buffer_as_uint64[idx]
+        context.state[idx] = context.state[idx] ⊻ unsafe_load(pbuf, idx)
     end
     bc = Vector{UInt64}(5)
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,8 +1,8 @@
 # Type hierarchy to aid in splitting up of SHA2 algorithms
 # as SHA224/256 are similar, and SHA-384/512 are similar
-@compat abstract type SHA_CTX end
-@compat abstract type SHA2_CTX <: SHA_CTX end
-@compat abstract type SHA3_CTX <: SHA_CTX end
+abstract type SHA_CTX end
+abstract type SHA2_CTX <: SHA_CTX end
+abstract type SHA3_CTX <: SHA_CTX end
 import Base: copy
 
 # We derive SHA1_CTX straight from SHA_CTX since it doesn't have a
@@ -102,7 +102,7 @@ blocklen(::Type{SHA3_512_CTX}) = UInt64(25*8 - 2*digestlen(SHA3_512_CTX))
 
 
 # short_blocklen is the size of a block minus the width of bytecount
-short_blocklen{T<:Union{SHA1_CTX,SHA2_CTX}}(::Type{T}) = blocklen(T) - 2*sizeof(state_type(T))
+short_blocklen(::Type{T}) where {T<:Union{SHA1_CTX,SHA2_CTX}} = blocklen(T) - 2*sizeof(state_type(T))
 
 # Once the "blocklen" methods are defined, we can define our outer constructors for SHA types:
 SHA2_224_CTX() = SHA2_224_CTX(copy(SHA2_224_initial_hash_value), 0, zeros(UInt8, blocklen(SHA2_224_CTX)))
@@ -126,9 +126,9 @@ SHA1_CTX() = SHA1_CTX(copy(SHA1_initial_hash_value), 0, zeros(UInt8, blocklen(SH
 
 
 # Copy functions
-copy{T <: SHA1_CTX}(ctx::T) = T(copy(ctx.state), ctx.bytecount, copy(ctx.buffer), copy(ctx.W))
-copy{T <: SHA2_CTX}(ctx::T) = T(copy(ctx.state), ctx.bytecount, copy(ctx.buffer))
-copy{T <: SHA3_CTX}(ctx::T) = T(copy(ctx.state), ctx.bytecount, copy(ctx.buffer))
+copy(ctx::T) where {T<:SHA1_CTX} = T(copy(ctx.state), ctx.bytecount, copy(ctx.buffer), copy(ctx.W))
+copy(ctx::T) where {T<:SHA2_CTX} = T(copy(ctx.state), ctx.bytecount, copy(ctx.buffer))
+copy(ctx::T) where {T<:SHA3_CTX} = T(copy(ctx.state), ctx.bytecount, copy(ctx.buffer))
 
 
 # Make printing these types a little friendlier

--- a/src/types.jl
+++ b/src/types.jl
@@ -7,7 +7,7 @@ import Base: copy
 
 # We derive SHA1_CTX straight from SHA_CTX since it doesn't have a
 # family of types like SHA2 or SHA3 do
-type SHA1_CTX <: SHA_CTX
+mutable struct SHA1_CTX <: SHA_CTX
     state::Array{UInt32,1}
     bytecount::UInt64
     buffer::Array{UInt8,1}
@@ -15,25 +15,25 @@ type SHA1_CTX <: SHA_CTX
 end
 
 # SHA2 224/256/384/512-bit Context Structures
-type SHA2_224_CTX <: SHA2_CTX
+mutable struct SHA2_224_CTX <: SHA2_CTX
     state::Array{UInt32,1}
     bytecount::UInt64
     buffer::Array{UInt8,1}
 end
 
-type SHA2_256_CTX <: SHA2_CTX
+mutable struct SHA2_256_CTX <: SHA2_CTX
     state::Array{UInt32,1}
     bytecount::UInt64
     buffer::Array{UInt8,1}
 end
 
-type SHA2_384_CTX <: SHA2_CTX
+mutable struct SHA2_384_CTX <: SHA2_CTX
     state::Array{UInt64,1}
     bytecount::UInt128
     buffer::Array{UInt8,1}
 end
 
-type SHA2_512_CTX <: SHA2_CTX
+mutable struct SHA2_512_CTX <: SHA2_CTX
     state::Array{UInt64,1}
     bytecount::UInt128
     buffer::Array{UInt8,1}
@@ -47,22 +47,22 @@ const SHA512_CTX = SHA2_512_CTX
 
 
 # SHA3 224/256/384/512-bit context structures
-type SHA3_224_CTX <: SHA3_CTX
+mutable struct SHA3_224_CTX <: SHA3_CTX
     state::Array{UInt64,1}
     bytecount::UInt128
     buffer::Array{UInt8,1}
 end
-type SHA3_256_CTX <: SHA3_CTX
+mutable struct SHA3_256_CTX <: SHA3_CTX
     state::Array{UInt64,1}
     bytecount::UInt128
     buffer::Array{UInt8,1}
 end
-type SHA3_384_CTX <: SHA3_CTX
+mutable struct SHA3_384_CTX <: SHA3_CTX
     state::Array{UInt64,1}
     bytecount::UInt128
     buffer::Array{UInt8,1}
 end
-type SHA3_512_CTX <: SHA3_CTX
+mutable struct SHA3_512_CTX <: SHA3_CTX
     state::Array{UInt64,1}
     bytecount::UInt128
     buffer::Array{UInt8,1}

--- a/src/types.jl
+++ b/src/types.jl
@@ -116,10 +116,10 @@ SHA3_384_CTX() = SHA3_384_CTX(zeros(UInt64, 25), 0, zeros(UInt8, blocklen(SHA3_3
 SHA3_512_CTX() = SHA3_512_CTX(zeros(UInt64, 25), 0, zeros(UInt8, blocklen(SHA3_512_CTX)))
 
 # Nickname'd outer constructor methods for SHA2
-SHA224_CTX = SHA2_224_CTX
-SHA256_CTX = SHA2_256_CTX
-SHA384_CTX = SHA2_384_CTX
-SHA512_CTX = SHA2_512_CTX
+const SHA224_CTX = SHA2_224_CTX
+const SHA256_CTX = SHA2_256_CTX
+const SHA384_CTX = SHA2_384_CTX
+const SHA512_CTX = SHA2_512_CTX
 
 # SHA1 is special; he needs extra workspace
 SHA1_CTX() = SHA1_CTX(copy(SHA1_initial_hash_value), 0, zeros(UInt8, blocklen(SHA1_CTX)), Vector{UInt32}(80))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -199,8 +199,11 @@ for sha_idx in 1:length(sha_funcs)
 end
 println("Done! [$(nerrors - nerrors_old) errors]")
 
-if VERSION >= v"0.5.0-pre+5599" replstr(x) = sprint((io, x) -> show(IOContext(io, limit=true), MIME("text/plain"), x), x)
-else replstr(x) = sprint((io, x) -> writemime(io, MIME("text/plain"), x), x) end
+if VERSION >= v"0.7.0-DEV.1472"
+    replstr(x) = sprint((io, x) -> show(IOContext(io, :limit => true), MIME("text/plain"), x), x)
+else
+    replstr(x) = sprint((io, x) -> show(IOContext(io, limit=true), MIME("text/plain"), x), x)
+end
 
 for idx in 1:length(ctxs)
     # Part #1: copy

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,15 +3,17 @@ using Compat
 
 # Define some data we will run our tests on
 lorem = "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
-so_many_as = repmat([0x61], 1000000)
+so_many_as_array = repmat([0x61], 1000000)
+so_many_as_tuple = ntuple((i) -> 0x61, 1000000)
 file = ".sha"  # Subject to change
 fIO = open(file, "w")
 write(fIO, '\0')
 close(fIO)
-data = Any["", "test", lorem, file, so_many_as]
+data = Any["", "test", lorem, file, so_many_as_array, so_many_as_tuple]
 
 # Descriptions of the data, the SHA functions we'll run on the data, etc...
-data_desc = ["the empty string", "the string \"test\"", "lorem ipsum", "0 file", "one million a's"]
+data_desc = ["the empty string", "the string \"test\"", "lorem ipsum",
+             "0 file", "one million a's Array", "one million a's Tuple"]
 sha_types = Dict(sha1 => SHA.SHA1_CTX,
             sha2_224 => SHA.SHA2_224_CTX, sha2_256 => SHA.SHA2_256_CTX, sha2_384 => SHA.SHA2_384_CTX, sha2_512 => SHA.SHA2_512_CTX,
             sha3_224 => SHA.SHA3_224_CTX, sha3_256 => SHA.SHA3_256_CTX, sha3_384 => SHA.SHA3_384_CTX, sha3_512 => SHA.SHA3_512_CTX)
@@ -32,12 +34,14 @@ sha1 => [
 "19afa2a4a37462c7b940a6c4c61363d49c3a35f4",
 "5ba93c9db0cff93f52b521d7420e43f6eda2784f",
 "34aa973cd4c4daa4f61eeb2bdbad27316534016f",
+"34aa973cd4c4daa4f61eeb2bdbad27316534016f"
 ],
 sha2_224 => [
 "d14a028c2a3a2bc9476102bb288234c415a2b01f828ea62ac5b3e42f",
 "90a3ed9e32b2aaf4c61c410eb925426119e1a9dc53d4286ade99a809",
 "6a0644abcf1e2cecbec2814443dab5f24b7ad8ebb66c75667ab67959",
 "fff9292b4201617bdc4d3053fce02734166a683d7d858a7f5f59b073",
+"20794655980c91d8bbb4c1ea97618a4bf03f42581948b2ee4ee7ad67",
 "20794655980c91d8bbb4c1ea97618a4bf03f42581948b2ee4ee7ad67"
 ],
 sha2_256 => [
@@ -45,6 +49,7 @@ sha2_256 => [
 "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
 "2c7c3d5f244f1a40069a32224215e0cf9b42485c99d80f357d76f006359c7a18",
 "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d",
+"cdc76e5c9914fb9281a1c7e284d73e67f1809a48a497200e046d39ccc7112cd0",
 "cdc76e5c9914fb9281a1c7e284d73e67f1809a48a497200e046d39ccc7112cd0"
 ],
 sha2_384 => [
@@ -52,6 +57,7 @@ sha2_384 => [
 "768412320f7b0aa5812fce428dc4706b3cae50e02a64caa16a782249bfe8efc4b7ef1ccb126255d196047dfedf17a0a9",
 "63980fd0425cd2c3d8a400ee0f2671ef135db03b947ec1af21b6e28f19c16ca272036469541f4d8e336ac6d1da50580f",
 "bec021b4f368e3069134e012c2b4307083d3a9bdd206e24e5f0d86e13d6636655933ec2b413465966817a9c208a11717",
+"9d0e1809716474cb086e834e310a4a1ced149e9c00f248527972cec5704c2a5b07b8b3dc38ecc4ebae97ddd87f3d8985",
 "9d0e1809716474cb086e834e310a4a1ced149e9c00f248527972cec5704c2a5b07b8b3dc38ecc4ebae97ddd87f3d8985"
 ],
 sha2_512 => [
@@ -59,6 +65,7 @@ sha2_512 => [
 "ee26b0dd4af7e749aa1a8ee3c10ae9923f618980772e473f8819a5d4940e0db27ac185f8a0e1d5f84f88bc887fd67b143732c304cc5fa9ad8e6f57f50028a8ff",
 "f41d92bc9fc1157a0d1387e67f3d0893b70f7039d3d46d8115b5079d45ad601159398c79c281681e2da09bf7d9f8c23b41d1a0a3c5b528a7f2735933a4353194",
 "b8244d028981d693af7b456af8efa4cad63d282e19ff14942c246e50d9351d22704a802a71c3580b6370de4ceb293c324a8423342557d4e5c38438f0e36910ee",
+"e718483d0ce769644e2e42c7bc15b4638e1f98b13b2044285632a803afa973ebde0ff244877ea60a4cb0432ce577c31beb009c5c2c49aa2e4eadb217ad8cc09b",
 "e718483d0ce769644e2e42c7bc15b4638e1f98b13b2044285632a803afa973ebde0ff244877ea60a4cb0432ce577c31beb009c5c2c49aa2e4eadb217ad8cc09b"
 ],
 sha3_224 => [
@@ -66,6 +73,7 @@ sha3_224 => [
 "3797bf0afbbfca4a7bbba7602a2b552746876517a7f9b7ce2db0ae7b",
 "ea5395370949ad8c7d2ca3e7c045ef3306fe3a3f4740de452ef87a28",
 "bdd5167212d2dc69665f5a8875ab87f23d5ce7849132f56371a19096",
+"d69335b93325192e516a912e6d19a15cb51c6ed5c15243e7a7fd653c",
 "d69335b93325192e516a912e6d19a15cb51c6ed5c15243e7a7fd653c"
 ],
 sha3_256 => [
@@ -73,21 +81,24 @@ sha3_256 => [
 "36f028580bb02cc8272a9a020f4200e346e276ae664e45ee80745574e2f5ab80",
 "8c8142d2ca964ab307ace567ddd5764f17ebb76eb8ff25543ab54c14fe2ab139",
 "5d53469f20fef4f8eab52b88044ede69c77a6a68a60728609fc4a65ff531e7d0",
-"5c8875ae474a3634ba4fd55ec85bffd661f32aca75c6d699d0cdcb6c115891c1"
+"5c8875ae474a3634ba4fd55ec85bffd661f32aca75c6d699d0cdcb6c115891c1",
+"5c8875ae474a3634ba4fd55ec85bffd661f32aca75c6d699d0cdcb6c115891c1",
 ],
 sha3_384 => [
 "0c63a75b845e4f7d01107d852e4c2485c51a50aaaa94fc61995e71bbee983a2ac3713831264adb47fb6bd1e058d5f004",
 "e516dabb23b6e30026863543282780a3ae0dccf05551cf0295178d7ff0f1b41eecb9db3ff219007c4e097260d58621bd",
 "eb9fbba3eb916a4efe384b3125f5d03ceb9c5c1b94431ac30fa86c54408b92701ca5d2628cd7113aa5541177ec3ccd1d",
 "127677f8b66725bbcb7c3eae9698351ca41e0eb6d66c784bd28dcdb3b5fb12d0c8e840342db03ad1ae180b92e3504933",
-"eee9e24d78c1855337983451df97c8ad9eedf256c6334f8e948d252d5e0e76847aa0774ddb90a842190d2c558b4b8340"
+"eee9e24d78c1855337983451df97c8ad9eedf256c6334f8e948d252d5e0e76847aa0774ddb90a842190d2c558b4b8340",
+"eee9e24d78c1855337983451df97c8ad9eedf256c6334f8e948d252d5e0e76847aa0774ddb90a842190d2c558b4b8340",
 ],
 sha3_512 => [
 "a69f73cca23a9ac5c8b567dc185a756e97c982164fe25859e0d1dcc1475c80a615b2123af1f5f94c11e3e9402c3ac558f500199d95b6d3e301758586281dcd26",
 "9ece086e9bac491fac5c1d1046ca11d737b92a2b2ebd93f005d7b710110c0a678288166e7fbe796883a4f2e9b3ca9f484f521d0ce464345cc1aec96779149c14",
 "3a4318353396a12dfd20442cfce1d8ad4d7e732e85cc56b01b4cf9057a41c8827c0a03c70812e76ace68d776759225c213b4f581aac0dba5dd43b785b1a33fe5",
 "7127aab211f82a18d06cf7578ff49d5089017944139aa60d8bee057811a15fb55a53887600a3eceba004de51105139f32506fe5b53e1913bfa6b32e716fe97da",
-"3c3a876da14034ab60627c077bb98f7e120a2a5370212dffb3385a18d4f38859ed311d0a9d5141ce9cc5c66ee689b266a8aa18ace8282a0e0db596c90b0a7b87"
+"3c3a876da14034ab60627c077bb98f7e120a2a5370212dffb3385a18d4f38859ed311d0a9d5141ce9cc5c66ee689b266a8aa18ace8282a0e0db596c90b0a7b87",
+"3c3a876da14034ab60627c077bb98f7e120a2a5370212dffb3385a18d4f38859ed311d0a9d5141ce9cc5c66ee689b266a8aa18ace8282a0e0db596c90b0a7b87",
 ]
 )
 
@@ -140,8 +151,8 @@ print("Testing on one million a's (chunked properly)")
 nerrors_old = nerrors
 for sha_idx in 1:length(sha_funcs)
     ctx = sha_types[sha_funcs[sha_idx]]()
-    SHA.update!(ctx, so_many_as[1:2*SHA.blocklen(typeof(ctx))])
-    SHA.update!(ctx, so_many_as[2*SHA.blocklen(typeof(ctx))+1:end])
+    SHA.update!(ctx, so_many_as_array[1:2*SHA.blocklen(typeof(ctx))])
+    SHA.update!(ctx, so_many_as_array[2*SHA.blocklen(typeof(ctx))+1:end])
     hash = bytes2hex(SHA.digest!(ctx))
     if hash != answers[sha_funcs[sha_idx]][end]
         print("\n")
@@ -173,13 +184,13 @@ for sha_idx in 1:length(sha_funcs)
     idx2 = round(Int, 2.6*SHA.blocklen(typeof(ctx)))
 
     # Feed data in according to our dastardly blocking scheme
-    SHA.update!(ctx, so_many_as[0      + 1:1*idx0])
-    SHA.update!(ctx, so_many_as[1*idx0 + 1:2*idx0])
-    SHA.update!(ctx, so_many_as[2*idx0 + 1:3*idx0])
-    SHA.update!(ctx, so_many_as[3*idx0 + 1:4*idx0])
-    SHA.update!(ctx, so_many_as[4*idx0 + 1:idx1])
-    SHA.update!(ctx, so_many_as[idx1 + 1:idx2])
-    SHA.update!(ctx, so_many_as[idx2 + 1:end])
+    SHA.update!(ctx, so_many_as_array[0      + 1:1*idx0])
+    SHA.update!(ctx, so_many_as_array[1*idx0 + 1:2*idx0])
+    SHA.update!(ctx, so_many_as_array[2*idx0 + 1:3*idx0])
+    SHA.update!(ctx, so_many_as_array[3*idx0 + 1:4*idx0])
+    SHA.update!(ctx, so_many_as_array[4*idx0 + 1:idx1])
+    SHA.update!(ctx, so_many_as_array[idx1 + 1:idx2])
+    SHA.update!(ctx, so_many_as_array[idx2 + 1:end])
 
     # Ensure the hash is the appropriate one
     hash = bytes2hex(SHA.digest!(ctx))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -238,6 +238,16 @@ for idx in 1:length(ctxs)
     println("Done! [$(nerrors - nerrors_old) errors]")
 end
 
+# test error if eltype of input is not UInt8
+for f in sha_funcs
+    try
+        f(UInt32[0x23467, 0x324775])
+        warn("Non-UInt8 Arrays should fail")
+        nerrors += 1
+    end
+end
+
+
 # Clean up the I/O mess
 rm(file)
 


### PR DESCRIPTION
Hashing for `NTuple{N, UInt8}`

had to change `Array{UInt8, 1}` to `Array{UInt8, N}` in `sha*` and `update!` for some reason, else I get the following error:
```
ERROR: LoadError: MethodError: no method matching sha1(::Array{UInt8,1})
Closest candidates are:
  sha1(::Union{Array{UInt8,1}, Tuple{Vararg{UInt8,N}}}) where N at /home/gkraemer/.julia/v0.6/SHA/src/SHA.jl:42
  sha1(!Matched::AbstractString) at /home/gkraemer/.julia/v0.6/SHA/src/SHA.jl:48
  sha1(!Matched::IO) at /home/gkraemer/.julia/v0.6/SHA/src/SHA.jl:54
```
