### PR TITLE
Fix wrong use of reinterpret

### DIFF
--- a/src/common.jl
+++ b/src/common.jl
@@ -65,9 +65,9 @@ function digest!{T<:Union{SHA1_CTX,SHA2_CTX}}(context::T)
     end
 
     # Store the length of the input data (in bits) at the end of the padding
-    bitcount_buffer = reinterpret(typeof(context.bytecount), context.buffer)
-    bitcount_idx = div(short_blocklen(T), sizeof(context.bytecount))+1
-    bitcount_buffer[bitcount_idx] = bswap(context.bytecount*8)
+    bitcount_idx = div(short_blocklen(T), sizeof(context.bytecount)) + 1
+    pbuf = Ptr{typeof(context.bytecount)}(pointer(context.buffer))
+    unsafe_store!(pbuf, bswap(context.bytecount * 8), bitcount_idx)
 
     # Final transform:
     transform!(context)

--- a/src/sha1.jl
+++ b/src/sha1.jl
@@ -13,9 +13,9 @@ end
 
 function transform!(context::SHA1_CTX)
     # Buffer is 16 elements long, we expand to 80
-    buffer = reinterpret(eltype(context.state), context.buffer)
+    pbuf = Ptr{eltype(context.state)}(pointer(context.buffer))
     for i in 1:16
-        context.W[i] = bswap(buffer[i])
+        context.W[i] = bswap(unsafe_load(pbuf, i))
     end
 
     # First round of expansions

--- a/src/sha2.jl
+++ b/src/sha2.jl
@@ -1,5 +1,5 @@
 function transform!{T<:Union{SHA2_224_CTX,SHA2_256_CTX}}(context::T)
-    buffer = reinterpret(eltype(context.state), context.buffer)
+    pbuf = Ptr{eltype(context.state)}(pointer(context.buffer))
     # Initialize registers with the previous intermediate values (our state)
     a = context.state[1]
     b = context.state[2]
@@ -14,10 +14,11 @@ function transform!{T<:Union{SHA2_224_CTX,SHA2_256_CTX}}(context::T)
     for j = 1:16
         @inbounds begin
             # We bitswap every input byte
-            buffer[j] = bswap(buffer[j])
+            v = bswap(unsafe_load(pbuf, j))
+            unsafe_store!(pbuf, v, j)
 
             # Apply the SHA-256 compression function to update a..h
-            T1 = h + Sigma1_256(e) + Ch(e, f, g) + K256[j] + buffer[j]
+            T1 = h + Sigma1_256(e) + Ch(e, f, g) + K256[j] + v
             T2 = Sigma0_256(a) + Maj(a, b, c)
             h = g
             g = f
@@ -33,14 +34,15 @@ function transform!{T<:Union{SHA2_224_CTX,SHA2_256_CTX}}(context::T)
     for j = 17:64
         @inbounds begin
             # Implicit message block expansion:
-            s0 = buffer[mod1(j + 1, 16)]
+            s0 = unsafe_load(pbuf, mod1(j + 1, 16))
             s0 = sigma0_256(s0)
-            s1 = buffer[mod1(j + 14, 16)]
+            s1 = unsafe_load(pbuf, mod1(j + 14, 16))
             s1 = sigma1_256(s1)
 
             # Apply the SHA-256 compression function to update a..h
-            buffer[mod1(j, 16)] += s1 + buffer[mod1(j + 9,16)] + s0
-            T1 = h + Sigma1_256(e) + Ch(e, f, g) + K256[j] + buffer[mod1(j, 16)]
+            v = unsafe_load(pbuf, mod1(j, 16)) + s1 + unsafe_load(pbuf, mod1(j + 9, 16)) + s0
+            unsafe_store!(pbuf, v, mod1(j, 16))
+            T1 = h + Sigma1_256(e) + Ch(e, f, g) + K256[j] + v
             T2 = Sigma0_256(a) + Maj(a, b, c)
             h = g
             g = f
@@ -66,7 +68,7 @@ end
 
 
 function transform!(context::Union{SHA2_384_CTX,SHA2_512_CTX})
-    buffer = reinterpret(eltype(context.state), context.buffer)
+    pbuf = Ptr{eltype(context.state)}(pointer(context.buffer))
     # Initialize registers with the prev. intermediate value
     a = context.state[1]
     b = context.state[2]
@@ -79,10 +81,11 @@ function transform!(context::Union{SHA2_384_CTX,SHA2_512_CTX})
 
     for j = 1:16
         @inbounds begin
-            buffer[j] = bswap(buffer[j])
+            v = bswap(unsafe_load(pbuf, j))
+            unsafe_store!(pbuf, v, j)
 
             # Apply the SHA-512 compression function to update a..h
-            T1 = h + Sigma1_512(e) + Ch(e, f, g) + K512[j] + buffer[j]
+            T1 = h + Sigma1_512(e) + Ch(e, f, g) + K512[j] + v
             T2 = Sigma0_512(a) + Maj(a, b, c)
             h = g
             g = f
@@ -98,14 +101,15 @@ function transform!(context::Union{SHA2_384_CTX,SHA2_512_CTX})
     for j = 17:80
         @inbounds begin
             # Implicit message block expansion:
-            s0 = buffer[mod1(j + 1, 16)]
+            s0 = unsafe_load(pbuf, mod1(j + 1, 16))
             s0 = sigma0_512(s0)
-            s1 = buffer[mod1(j+14, 16)]
+            s1 = unsafe_load(pbuf, mod1(j + 14, 16))
             s1 = sigma1_512(s1)
 
             # Apply the SHA-512 compression function to update a..h
-            buffer[mod1(j, 16)] += s1 + buffer[mod1(j+9, 16)] + s0
-            T1 = h + Sigma1_512(e) + Ch(e, f, g) + K512[j] + buffer[mod1(j, 16)]
+            v = unsafe_load(pbuf, mod1(j, 16)) + s1 + unsafe_load(pbuf, mod1(j + 9, 16)) + s0
+            unsafe_store!(pbuf, v, mod1(j, 16))
+            T1 = h + Sigma1_512(e) + Ch(e, f, g) + K512[j] + v
             T2 = Sigma0_512(a) + Maj(a, b, c)
             h = g
             g = f

--- a/src/sha3.jl
+++ b/src/sha3.jl
@@ -1,8 +1,8 @@
 function transform!{T<:SHA3_CTX}(context::T)
     # First, update state with buffer
-    buffer_as_uint64 = reinterpret(eltype(context.state), context.buffer)
+    pbuf = Ptr{eltype(context.state)}(pointer(context.buffer))
     for idx in 1:div(blocklen(T),8)
-        context.state[idx] = context.state[idx] ⊻ buffer_as_uint64[idx]
+        context.state[idx] = context.state[idx] ⊻ unsafe_load(pbuf, idx)
     end
     bc = Vector{UInt64}(5)
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -116,10 +116,10 @@ SHA3_384_CTX() = SHA3_384_CTX(zeros(UInt64, 25), 0, zeros(UInt8, blocklen(SHA3_3
 SHA3_512_CTX() = SHA3_512_CTX(zeros(UInt64, 25), 0, zeros(UInt8, blocklen(SHA3_512_CTX)))
 
 # Nickname'd outer constructor methods for SHA2
-SHA224_CTX = SHA2_224_CTX
-SHA256_CTX = SHA2_256_CTX
-SHA384_CTX = SHA2_384_CTX
-SHA512_CTX = SHA2_512_CTX
+const SHA224_CTX = SHA2_224_CTX
+const SHA256_CTX = SHA2_256_CTX
+const SHA384_CTX = SHA2_384_CTX
+const SHA512_CTX = SHA2_512_CTX
 
 # SHA1 is special; he needs extra workspace
 SHA1_CTX() = SHA1_CTX(copy(SHA1_initial_hash_value), 0, zeros(UInt8, blocklen(SHA1_CTX)), Vector{UInt32}(80))


### PR DESCRIPTION
This is the simplest and the most local fix I can come up with. If the `buffer` field is not meant to be publically accessed, it is better to use a wider array and reinterpret back to `UInt8` if it needs to be accessed as bytes.

@staticfloat