### PR TITLE
add HMAC functionalities

### DIFF
--- a/src/hmac.jl
+++ b/src/hmac.jl
@@ -1,0 +1,33 @@
+struct HMAC_CTX{CTX<:SHA_CTX}
+    context::CTX
+    outer::Vector{UInt8}
+
+    function HMAC_CTX(ctx::CTX, key::Vector{UInt8}, blocksize::Integer=blocklen(CTX)) where CTX
+        if length(key) > blocksize
+            _ctx = CTX()
+            update!(_ctx, key)
+            key = digest!(_ctx)
+        end
+
+        pad = blocksize - length(key)
+
+        if pad > 0
+            key = [key; fill(0x00, pad)]
+        end
+
+        update!(ctx, key .⊻ 0x36)
+        new{CTX}(ctx, key .⊻ 0x5c)
+    end
+end
+
+function update!(ctx::HMAC_CTX, data)
+    update!(ctx.context, data)
+end
+
+function digest!(ctx::HMAC_CTX{CTX}) where CTX
+    digest = digest!(ctx.context)
+    _ctx = CTX()
+    update!(_ctx, ctx.outer)
+    update!(_ctx, digest)
+    digest!(_ctx)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -209,6 +209,32 @@ for sha_idx in 1:length(sha_funcs)
 end
 println("Done! [$(nerrors - nerrors_old) errors]")
 
+# test hmac correctness using the examples on [wiki](https://en.wikipedia.org/wiki/Hash-based_message_authentication_code#Examples)
+print("Testing on the hmac functions")
+nerrors_old = nerrors
+for (key, msg, fun, hash) in (
+    (b"", b"", hmac_sha1, "fbdb1d1b18aa6c08324b7d64b71fb76370690e1d"),
+    (b"", b"", hmac_sha256, "b613679a0814d9ec772f95d778c35fc5ff1697c493715653c6c712144292c5ad"),
+    (b"key", b"The quick brown fox jumps over the lazy dog", hmac_sha1, "de7c9b85b8b78aa6bc8a7a36f70a90701c9db4d9"),
+    (b"key", b"The quick brown fox jumps over the lazy dog", hmac_sha256, "f7bc83f430538424b13298e6aa6fb143ef4d59a14946175997479dbc2d1a3cd8"),
+)
+    digest = bytes2hex(fun(key, msg))
+    if digest != hash
+        print("\n")
+        warn(
+        """
+        For $fun($(String(key)), $(String(msg))) expected:
+            $hash
+        Calculated:
+            $digest
+        """)
+        nerrors += 1
+    else
+        print(".")
+    end
+end
+println("Done! [$(nerrors - nerrors_old) errors]")
+
 if VERSION >= v"0.7.0-DEV.1472"
     replstr(x) = sprint((io, x) -> show(IOContext(io, :limit => true), MIME("text/plain"), x), x)
 else


### PR DESCRIPTION
This PR adds HMAC functionality by
- an `HMAC_CTX` that has the same `update!` and `digest!` interface with `SHA_CTX`s. It can be instantialized with an `SHA_CTX` and a key.
- convenient methods with prefix `hmac_` which accept a key as the first argument.
- some test cases from [wiki](https://en.wikipedia.org/wiki/Hash-based_message_authentication_code#Examples)

> When opening an issue, please ping `@staticfloat` since he does not receive emails automatically when new issues are created.
