### PR TITLE
=Use abstract type, not union

### DIFF
--- a/src/common.jl
+++ b/src/common.jl
@@ -2,7 +2,7 @@
 
 # update! takes in variable-length data, buffering it into blocklen()-sized pieces,
 # calling transform!() when necessary to update the internal hash state.
-function update!(context::T, data::U) where {T<:Union{SHA1_CTX,SHA2_CTX,SHA3_CTX},
+function update!(context::T, data::U) where {T<:SHA_CTX,
                                              U<:Union{Array{UInt8,1},NTuple{N,UInt8} where N}}
     # We need to do all our arithmetic in the proper bitwidth
     UIntXXX = typeof(context.bytecount)


### PR DESCRIPTION
@staticfloat

Abstract Types are more extendable than Unions.
I spotted that this one already existed and wasn't being used.

I believe this covers the same types.

I also believe that I can maybe use this for making `update!(::MD5_CTX)` work.
if so it suggest that a more abstract type  perhaps 
`MerkleDamgård_CTX` (:-P) might be in order,
but that is getting ahead of myself.
For the purposes of SHA.jl, this is just slightly cleaner code


