### PR TITLE
Abstractions for MD5.jl

### DIFF
--- a/src/common.jl
+++ b/src/common.jl
@@ -2,7 +2,7 @@
 
 # update! takes in variable-length data, buffering it into blocklen()-sized pieces,
 # calling transform!() when necessary to update the internal hash state.
-function update!(context::T, data::U) where {T<:Union{SHA1_CTX,SHA2_CTX,SHA3_CTX},
+function update!(context::T, data::U) where {T<:SHA_CTX,
                                              U<:Union{Array{UInt8,1},NTuple{N,UInt8} where N}}
     # We need to do all our arithmetic in the proper bitwidth
     UIntXXX = typeof(context.bytecount)

--- a/src/sha1.jl
+++ b/src/sha1.jl
@@ -13,7 +13,7 @@ end
 
 function transform!(context::SHA1_CTX)
     # Buffer is 16 elements long, we expand to 80
-    pbuf = Ptr{eltype(context.state)}(pointer(context.buffer))
+    pbuf = buffer_pointer(context)
     for i in 1:16
         context.W[i] = bswap(unsafe_load(pbuf, i))
     end

--- a/src/sha2.jl
+++ b/src/sha2.jl
@@ -1,5 +1,5 @@
 function transform!(context::T) where {T<:Union{SHA2_224_CTX,SHA2_256_CTX}}
-    pbuf = Ptr{eltype(context.state)}(pointer(context.buffer))
+    pbuf = buffer_pointer(context)
     # Initialize registers with the previous intermediate values (our state)
     a = context.state[1]
     b = context.state[2]
@@ -68,7 +68,7 @@ end
 
 
 function transform!(context::Union{SHA2_384_CTX,SHA2_512_CTX})
-    pbuf = Ptr{eltype(context.state)}(pointer(context.buffer))
+    pbuf = buffer_pointer(context)
     # Initialize registers with the prev. intermediate value
     a = context.state[1]
     b = context.state[2]

--- a/src/types.jl
+++ b/src/types.jl
@@ -87,6 +87,7 @@ state_type(::Type{SHA2_224_CTX}) = UInt32
 state_type(::Type{SHA2_256_CTX}) = UInt32
 state_type(::Type{SHA2_384_CTX}) = UInt64
 state_type(::Type{SHA2_512_CTX}) = UInt64
+state_type(::Type{SHA3_CTX}) = UInt64
 
 # blocklen is the number of bytes of data processed by the transform!() function at once
 blocklen(::Type{SHA1_CTX}) = UInt64(64)
@@ -102,7 +103,7 @@ blocklen(::Type{SHA3_512_CTX}) = UInt64(25*8 - 2*digestlen(SHA3_512_CTX))
 
 
 # short_blocklen is the size of a block minus the width of bytecount
-short_blocklen(::Type{T}) where {T<:Union{SHA1_CTX,SHA2_CTX}} = blocklen(T) - 2*sizeof(state_type(T))
+short_blocklen(::Type{T}) where {T<:SHA_CTX} = blocklen(T) - 2*sizeof(state_type(T))
 
 # Once the "blocklen" methods are defined, we can define our outer constructors for SHA types:
 SHA2_224_CTX() = SHA2_224_CTX(copy(SHA2_224_initial_hash_value), 0, zeros(UInt8, blocklen(SHA2_224_CTX)))
@@ -142,3 +143,7 @@ show(io::IO, ::SHA3_224_CTX) = write(io, "SHA3 224-bit hash state")
 show(io::IO, ::SHA3_256_CTX) = write(io, "SHA3 256-bit hash state")
 show(io::IO, ::SHA3_384_CTX) = write(io, "SHA3 384-bit hash state")
 show(io::IO, ::SHA3_512_CTX) = write(io, "SHA3 512-bit hash state")
+
+
+# use out types to define a method to get a pointer to the state buffer
+buffer_pointer(ctx::T) where {T<:SHA_CTX} = Ptr{state_type(T)}(pointer(ctx.buffer))


### PR DESCRIPTION
@staticfloat

I have split-up some methods: (I think just) `pad_remainder` from `digest!`
and I have added a some methods: (I think just) `buffer_pointer`
and made a few tweaks.

By doing this I can just call SHA.jl from MD5.jl for a lot of the work.
