### PR TITLE
allow AbstractVector{UInt8}, make fewer copies

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
 julia 0.6
-Compat 0.45
+Compat 0.50.0

--- a/src/SHA.jl
+++ b/src/SHA.jl
@@ -16,6 +16,8 @@ export hmac_sha224, hmac_sha256, hmac_sha384, hmac_sha512
 export hmac_sha2_224, hmac_sha2_256, hmac_sha2_384, hmac_sha2_512
 export hmac_sha3_224, hmac_sha3_256, hmac_sha3_384, hmac_sha3_512
 
+# data to be hashed:
+const AbstractBytes = Union{AbstractVector{UInt8},NTuple{N,UInt8} where N}
 
 include("constants.jl")
 include("types.jl")
@@ -25,11 +27,6 @@ include("sha2.jl")
 include("sha3.jl")
 include("common.jl")
 include("hmac.jl")
-
-# Compat.jl-like shim for codeunits() on Julia <= 0.6:
-if VERSION < v"0.7.0-DEV.3213"
-    codeunits(x) = x
-end
 
 # Create data types and convenience functions for each hash implemented
 for (f, ctx) in [(:sha1, :SHA1_CTX),
@@ -49,20 +46,22 @@ for (f, ctx) in [(:sha1, :SHA1_CTX),
 
     @eval begin
         # Our basic function is to process arrays of bytes
-        function $f(data::T) where T<:Union{Array{UInt8,1},NTuple{N,UInt8} where N}
+        function $f(data::AbstractBytes)
             ctx = $ctx()
             update!(ctx, data)
             return digest!(ctx)
         end
-        function $g(key::Vector{UInt8}, data::T) where T<:Union{Array{UInt8,1},NTuple{N,UInt8} where N}
+        function $g(key::Vector{UInt8}, data::AbstractBytes)
             ctx = HMAC_CTX($ctx(), key)
             update!(ctx, data)
             return digest!(ctx)
         end
 
         # AbstractStrings are a pretty handy thing to be able to crunch through
-        $f(str::AbstractString) = $f(Vector{UInt8}(codeunits(str)))
-        $g(key::Vector{UInt8}, str::AbstractString) = $g(key, Vector{UInt8}(str))
+        $f(str::AbstractString) = $f(String(str)) # always crunch UTF-8 repr
+        $f(str::String) = $f(codeunits(str))
+        $g(key::Vector{UInt8}, str::AbstractString) = $g(key, String(str))
+        $g(key::Vector{UInt8}, str::String) = $g(key, codeunits(str))
 
         # Convenience function for IO devices, allows for things like:
         # open("test.txt") do f
@@ -73,7 +72,7 @@ for (f, ctx) in [(:sha1, :SHA1_CTX),
             buff = Vector{UInt8}(uninitialized, chunk_size)
             while !eof(io)
                 num_read = readbytes!(io, buff)
-                update!(ctx, buff[1:num_read])
+                update!(ctx, buff, num_read)
             end
             return digest!(ctx)
         end
@@ -82,7 +81,7 @@ for (f, ctx) in [(:sha1, :SHA1_CTX),
             buff = Vector{UInt8}(chunk_size)
             while !eof(io)
                 num_read = readbytes!(io, buff)
-                update!(ctx, buff[1:num_read])
+                update!(ctx, buff, num_read)
             end
             return digest!(ctx)
         end

--- a/src/common.jl
+++ b/src/common.jl
@@ -2,8 +2,7 @@
 
 # update! takes in variable-length data, buffering it into blocklen()-sized pieces,
 # calling transform!() when necessary to update the internal hash state.
-function update!(context::T, data::U, datalen=length(data)) where
-    {T<:SHA_CTX, U<:AbstractBytes}
+function update!(context::T, data::U, datalen=length(data)) where {T<:SHA_CTX, U<:AbstractBytes}
     # We need to do all our arithmetic in the proper bitwidth
     UIntXXX = typeof(context.bytecount)
 

--- a/src/common.jl
+++ b/src/common.jl
@@ -2,14 +2,15 @@
 
 # update! takes in variable-length data, buffering it into blocklen()-sized pieces,
 # calling transform!() when necessary to update the internal hash state.
-function update!(context::T, data::U) where {T<:SHA_CTX,
-                                             U<:Union{Array{UInt8,1},NTuple{N,UInt8} where N}}
+function update!(context::T, data::U, datalen=length(data)) where
+    {T<:SHA_CTX, U<:AbstractBytes}
     # We need to do all our arithmetic in the proper bitwidth
     UIntXXX = typeof(context.bytecount)
 
     # Process as many complete blocks as possible
-    len = convert(UIntXXX, length(data))
-    data_idx = convert(UIntXXX, 0)
+    0 ≤ datalen ≤ length(data) || throw(BoundsError(data, firstindex(data)+datalen-1))
+    len = convert(UIntXXX, datalen)
+    data_idx = convert(UIntXXX, firstindex(data)-1)
     usedspace = context.bytecount % blocklen(T)
     while len - data_idx + usedspace >= blocklen(T)
         # Fill up as much of the buffer as we can with the data given us

--- a/src/hmac.jl
+++ b/src/hmac.jl
@@ -20,8 +20,8 @@ struct HMAC_CTX{CTX<:SHA_CTX}
     end
 end
 
-function update!(ctx::HMAC_CTX, data)
-    update!(ctx.context, data)
+function update!(ctx::HMAC_CTX, data, datalen=length(data))
+    update!(ctx.context, data, datalen)
 end
 
 function digest!(ctx::HMAC_CTX{CTX}) where CTX


### PR DESCRIPTION
@staticfloat and @KristofferC, this PR allows one to hash data while making fewer copies:

* The type signature of the hashing functions is widened to accept `AbstractVector{UInt8}`

* When hashing a file, a `data[1:num_bytes]` slice copy is eliminated by adding an optional length argument to the internal `update!` function.  (I could have instead used `@views`, but this way I can eliminate the `SubArray` allocation.)

* A `String` is hashed by directly passing `codeunits(str)` (an `AbstractVector{UInt8}` in 0.7) to the hashing function.

Previously, arbitrary `AbstractString` objects were hashed by passing `Vector{UInt8}(codeunits(str))` to the hashing function, but this seemed wrong to me.  Not only does it mean that the hash becomes encoding dependent, but it will fail for something like a UTF-16 string where the code units cannot be converted to `UInt8`.  Instead, I convert other string types to `String`.