### PR TITLE
Improve performance of `transform!(::SHA3_CTX)` by using tuples internally

### DIFF
--- a/src/constants.jl
+++ b/src/constants.jl
@@ -138,13 +138,13 @@ const SHA3_ROUND_CONSTS = UInt64[
 ]
 
 # Rotation constants for SHA3 rounds
-const SHA3_ROTC = UInt64[
-    1,  3,  6,  10, 15, 21, 28, 36, 45, 55, 2,  14,
-    27, 41, 56, 8,  25, 43, 62, 18, 39, 61, 20, 44
-]
+const SHA3_ROTC = (
+     0,  1, 62, 28, 27, 36, 44,  6, 55, 20,  3, 10, 43,
+    25, 39, 41, 45, 15, 21,  8, 18,  2, 61, 56, 14,
+)
 
 # Permutation indices for SHA3 rounds (+1'ed so as to work with julia's 1-based indexing)
-const SHA3_PILN = Int[
-    11, 8,  12, 18, 19, 4, 6,  17, 9,  22, 25, 5,
-    16, 24, 20, 14, 13, 3, 21, 15, 23, 10,  7,  2
-]
+const SHA3_PILN = (
+     1,  7, 13, 19, 25,  4, 10, 11, 17, 23,  2,  8, 14,
+    20, 21,  5,  6, 12, 18, 24,  3,  9, 15, 16, 22,
+)

--- a/src/types.jl
+++ b/src/types.jl
@@ -72,28 +72,24 @@ mutable struct SHA3_224_CTX <: SHA3_CTX
     state::Vector{UInt64}
     bytecount::UInt128
     buffer::Vector{UInt8}
-    bc::Vector{UInt64}
     used::Bool
 end
 mutable struct SHA3_256_CTX <: SHA3_CTX
     state::Vector{UInt64}
     bytecount::UInt128
     buffer::Vector{UInt8}
-    bc::Vector{UInt64}
     used::Bool
 end
 mutable struct SHA3_384_CTX <: SHA3_CTX
     state::Vector{UInt64}
     bytecount::UInt128
     buffer::Vector{UInt8}
-    bc::Vector{UInt64}
     used::Bool
 end
 mutable struct SHA3_512_CTX <: SHA3_CTX
     state::Vector{UInt64}
     bytecount::UInt128
     buffer::Vector{UInt8}
-    bc::Vector{UInt64}
     used::Bool
 end
 
@@ -189,25 +185,25 @@ SHA2_512_256_CTX() = SHA2_512_256_CTX(copy(SHA2_512_256_initial_hash_value), 0, 
 
 Construct an empty SHA3_224 context.
 """
-SHA3_224_CTX() = SHA3_224_CTX(zeros(UInt64, 25), 0, zeros(UInt8, blocklen(SHA3_224_CTX)), Vector{UInt64}(undef, 5), false)
+SHA3_224_CTX() = SHA3_224_CTX(zeros(UInt64, 25), 0, zeros(UInt8, blocklen(SHA3_224_CTX)), false)
 """
     SHA3_256_CTX()
 
 Construct an empty SHA3_256 context.
 """
-SHA3_256_CTX() = SHA3_256_CTX(zeros(UInt64, 25), 0, zeros(UInt8, blocklen(SHA3_256_CTX)), Vector{UInt64}(undef, 5), false)
+SHA3_256_CTX() = SHA3_256_CTX(zeros(UInt64, 25), 0, zeros(UInt8, blocklen(SHA3_256_CTX)), false)
 """
     SHA3_384_CTX()
 
 Construct an empty SHA3_384 context.
 """
-SHA3_384_CTX() = SHA3_384_CTX(zeros(UInt64, 25), 0, zeros(UInt8, blocklen(SHA3_384_CTX)), Vector{UInt64}(undef, 5), false)
+SHA3_384_CTX() = SHA3_384_CTX(zeros(UInt64, 25), 0, zeros(UInt8, blocklen(SHA3_384_CTX)), false)
 """
     SHA3_512_CTX()
 
 Construct an empty SHA3_512 context.
 """
-SHA3_512_CTX() = SHA3_512_CTX(zeros(UInt64, 25), 0, zeros(UInt8, blocklen(SHA3_512_CTX)), Vector{UInt64}(undef, 5), false)
+SHA3_512_CTX() = SHA3_512_CTX(zeros(UInt64, 25), 0, zeros(UInt8, blocklen(SHA3_512_CTX)), false)
 
 # SHA1 is special; he needs extra workspace
 """
@@ -221,7 +217,7 @@ SHA1_CTX() = SHA1_CTX(copy(SHA1_initial_hash_value), 0, zeros(UInt8, blocklen(SH
 # Copy functions
 copy(ctx::T) where {T<:SHA1_CTX} = T(copy(ctx.state), ctx.bytecount, copy(ctx.buffer), copy(ctx.W), ctx.used)
 copy(ctx::T) where {T<:SHA2_CTX} = T(copy(ctx.state), ctx.bytecount, copy(ctx.buffer), ctx.used)
-copy(ctx::T) where {T<:SHA3_CTX} = T(copy(ctx.state), ctx.bytecount, copy(ctx.buffer), Vector{UInt64}(undef, 5), ctx.used)
+copy(ctx::T) where {T<:SHA3_CTX} = T(copy(ctx.state), ctx.bytecount, copy(ctx.buffer), ctx.used)
 
 
 # Make printing these types a little friendlier


### PR DESCRIPTION
This might put some more work on the compiler, but I'd say it's worth it:
```julia
julia> using BenchmarkTools, SHA

julia> versioninfo()
Julia Version 1.13.0-DEV.640
Commit 0a970d81aa (2025-05-27 03:57 UTC)
Platform Info:
  OS: Linux (x86_64-linux-gnu)
  CPU: 14 × Intel(R) Core(TM) Ultra 7 165U
  WORD_SIZE: 64
  LLVM: libLLVM-20.1.2 (ORCJIT, meteorlake)
  GC: Built with stock GC
Threads: 1 default, 1 interactive, 1 GC (on 14 virtual cores)

julia> @btime SHA.transform!($(SHA3_512_CTX()));
  790.098 ns (0 allocations: 0 bytes)    # master
  227.794 ns (0 allocations: 0 bytes)    # PR

julia> @btime sha3_224($(rand(UInt8, 100_000)));
  554.839 μs (9 allocations: 736 bytes)  # master
  152.336 μs (7 allocations: 624 bytes)  # PR

julia> @btime sha3_256($(rand(UInt8, 100_000)));
  566.486 μs (9 allocations: 720 bytes)  # master
  171.188 μs (7 allocations: 608 bytes)  # PR

julia> @btime sha3_384($(rand(UInt8, 100_000)));
  741.224 μs (9 allocations: 704 bytes)  # master
  228.926 μs (7 allocations: 592 bytes)  # PR

julia> @btime sha3_512($(rand(UInt8, 100_000)));
  1.132 ms (9 allocations: 688 bytes)    # master
  318.055 μs (7 allocations: 576 bytes)  # PR
```
I've benchmarked on Julia nightly as that is where an updated SHA.jl would end up eventually, but the trend on Julia 1.12 is the same. Might be interesting to check on another CPU, though.

I've briefly tried changing the `state` field of `SHA3_*_CTX` to a tuple, too, but that didn't change much (except for lowering the allocation count, of course). So I've left that as is, avoiding changes without benefit.

Closes #110, I'd say.